### PR TITLE
Use PCRE to speed up file system jail

### DIFF
--- a/.travis.test.py
+++ b/.travis.test.py
@@ -6,11 +6,11 @@ import os
 from dmoj import judgeenv
 from dmoj.citest import ci_test, get_dirs, make_override
 
-EXECUTORS = ['ADA', 'AWK', 'BF', 'C', 'CBL', 'D', 'DART', 'CPP0X', 'CPP03', 'CPP11', 'CLANG', 'CLANGX',
-             'F95', 'GO', 'GROOVY', 'HASK', 'JAVA8', 'JAVA9', 'OCAML',
+EXECUTORS = ['ADA', 'AWK', 'BF', 'C', 'CBL', 'D', 'DART', 'CPP03', 'CPP11', 'CLANG', 'CLANGX',
+             'F95', 'GO', 'HASK', 'JAVA8', 'OCAML',
              'PAS', 'PRO', 'GAS32', 'GAS64', 'LUA', 'NASM', 'NASM64',
              'PERL', 'PHP', 'PY2', 'PY3', 'PYPY', 'PYPY3',
-             'RUBY2', 'RUST', 'SCALA', 'SCM', 'SED', 'SWIFT', 'TCL', 'TEXT']
+             'RUBY2', 'RUST', 'SCM', 'SED', 'SWIFT', 'TCL', 'TEXT']
 
 RVM_DIR = os.path.expanduser('~/.rvm/rubies/')
 PYENV_DIR = '/opt/python/'
@@ -22,6 +22,7 @@ OVERRIDES = {
     'RUBY2': make_override('ruby2_home', RVM_DIR, r'ruby-2\.'),
     'PYPY': {'pypy_home': os.path.abspath('pypy2')},
     'PYPY3': {'pypy3_home': os.path.abspath('pypy3')},
+    'PHP': {'php': '/usr/bin/php'},
 }
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ python:
   - 3.6
   - 3.7
 env:
-- DMOJ_USE_SECCOMP="yes"
-- DMOJ_USE_SECCOMP="no"
+- DMOJ_USE_SECCOMP="yes" DMOJ_USE_PCRE="yes"
+- DMOJ_USE_SECCOMP="yes" DMOJ_USE_PCRE="no"
+- DMOJ_USE_SECCOMP="no" DMOJ_USE_PCRE="yes"
+- DMOJ_USE_SECCOMP="no" DMOJ_USE_PCRE="no"
 addons:
   apt:
     sources:
@@ -35,6 +37,7 @@ addons:
     - swi-prolog
     - dart/stable
     - scala
+    - libpcre2-dev
 cache:
   directories:
     - $HOME/.cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
+  - 3.7
 env:
 - DMOJ_USE_SECCOMP="yes"
 - DMOJ_USE_SECCOMP="no"
@@ -19,7 +19,7 @@ addons:
     packages:
     - ghc
     - gnat
-    - php5-cli
+    - php7.0-cli
     - fp-compiler
     - coffeescript
     - binutils-multiarch
@@ -45,7 +45,7 @@ before_install:
   # Install Swift
   - >
     mkdir swift &&
-    curl https://swift.org/builds/swift-2.2.1-release/ubuntu1404/swift-2.2.1-RELEASE/swift-2.2.1-RELEASE-ubuntu14.04.tar.gz |
+    curl https://swift.org/builds/swift-4.2.1-release/ubuntu1604/swift-4.2.1-RELEASE/swift-4.2.1-RELEASE-ubuntu16.04.tar.gz |
     tar xz -C swift --strip-components=1
   - export PATH=${PWD}/swift/usr/bin:"${PATH}"
   # Install PyPy

--- a/dmoj/cptbox/chroot.py
+++ b/dmoj/cptbox/chroot.py
@@ -6,7 +6,7 @@ import re
 import sys
 
 from dmoj.cptbox._cptbox import bsd_get_proc_cwd, bsd_get_proc_fdno, AT_FDCWD
-from dmoj.cptbox.handlers import ALLOW, ACCESS_DENIED, ACCESS_ENOENT, OPEN
+from dmoj.cptbox.handlers import ALLOW, ACCESS_DENIED, ACCESS_ENOENT, OPEN, OPENAT
 # noinspection PyUnresolvedReferences
 from dmoj.cptbox.syscalls import *
 from dmoj.utils.unicode import utf8text
@@ -195,6 +195,7 @@ class CHROOTSecurity(dict):
                 return True
             log.info('Denied access via syscall %s: %s', syscall, file)
             return ACCESS_ENOENT(debugger)
+        check.with_handler = OPENAT
         return check
 
     def _file_access_check(self, rel_file, debugger, orig_uarg0=None, flag_reg=1, dirfd=AT_FDCWD):

--- a/dmoj/cptbox/chroot.py
+++ b/dmoj/cptbox/chroot.py
@@ -203,6 +203,7 @@ class CHROOTSecurity(dict):
         except UnicodeDecodeError:
             log.exception('Unicode decoding error while opening relative to %d: %r', dirfd, rel_file)
             return '(undecodable)', False
+        print('Python checking:', file)
         if self.fs_jail.match(file) is None:
             return file, False
         return file, True

--- a/dmoj/cptbox/chroot.py
+++ b/dmoj/cptbox/chroot.py
@@ -6,7 +6,7 @@ import re
 import sys
 
 from dmoj.cptbox._cptbox import bsd_get_proc_cwd, bsd_get_proc_fdno, AT_FDCWD
-from dmoj.cptbox.handlers import ALLOW, ACCESS_DENIED, ACCESS_ENOENT
+from dmoj.cptbox.handlers import ALLOW, ACCESS_DENIED, ACCESS_ENOENT, OPEN
 # noinspection PyUnresolvedReferences
 from dmoj.cptbox.syscalls import *
 from dmoj.utils.unicode import utf8text
@@ -183,6 +183,7 @@ class CHROOTSecurity(dict):
                 return True
             log.info('Denied access via syscall %s: %s', syscall, file)
             return ACCESS_ENOENT(debugger)
+        check.with_handler = OPEN
         return check
 
     def check_file_access_at(self, syscall, is_open=False):

--- a/dmoj/cptbox/handlers.py
+++ b/dmoj/cptbox/handlers.py
@@ -4,7 +4,8 @@ DISALLOW = 0
 ALLOW = 1
 _CALLBACK = 2
 STDOUTERR = 3
-
+OPEN = 4
+OPENAT = 5
 
 def errno_handler(code):
     def handler(debugger):

--- a/dmoj/cptbox/posixpath.cpp
+++ b/dmoj/cptbox/posixpath.cpp
@@ -1,0 +1,61 @@
+#include "posixpath.h"
+#include <iterator>
+#include <string>
+#include <sstream>
+#include <vector>
+
+// Borrowed from https://stackoverflow.com/a/5289170/1090657
+template <typename Range, typename Value = typename Range::value_type>
+std::string string_join(Range const& elements, const char * delimiter) {
+    std::ostringstream os;
+    auto b = std::begin(elements), e = std::end(elements);
+
+    if (b != e) {
+        std::copy(b, prev(e), std::ostream_iterator<Value>(os, delimiter));
+        b = prev(e);
+    }
+
+    if (b != e) {
+        os << *b;
+    }
+
+    return os.str();
+}
+
+namespace posixpath {
+    std::string join(const std::string &parent, const std::string &child) {
+        if (!child.empty() && child[0] == '/') {
+            return child;
+        }
+        if (parent.empty() || parent.back() == '/') {
+            return parent + child;
+        } else {
+            return parent + "/" + child;
+        }
+    }
+
+    std::string normpath(const std::string &path) {
+        if (path.empty()) {
+            return ".";
+        }
+
+        bool absolute = path[0] == '/';
+        std::istringstream stream(path);
+        std::string token;
+        std::vector<std::string> comps;
+
+        while (std::getline(stream, token, '/')) {
+            if (token.empty() || token == ".")
+                continue;
+            if (token != ".." || (!absolute && comps.empty()) ||
+                    (!comps.empty() && comps.back() == "..")) {
+                comps.push_back(token);
+            } else if (!comps.empty()) {
+                comps.pop_back();
+            }
+        }
+
+        auto result = string_join(comps, "/");
+        return absolute ? "/" + result : result;
+    }
+}

--- a/dmoj/cptbox/posixpath.h
+++ b/dmoj/cptbox/posixpath.h
@@ -1,0 +1,13 @@
+#pragma once
+#ifndef id2E2DA71A_EAAB_4454_927325D6475896EC
+#define id2E2DA71A_EAAB_4454_927325D6475896EC
+
+#include <string>
+
+namespace posixpath {
+    std::string join(const std::string &parent, const std::string &child);
+    std::string normpath(const std::string &path);
+}
+
+#endif // id2E2DA71A_EAAB_4454_927325D6475896EC
+

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -194,6 +194,8 @@ public:
     pid_t tid; // TODO maybe call super instead
     pid_t getpid() { return process->getpid(); }
 
+    std::string get_fd(int fd);
+
 #if PTBOX_FREEBSD
     void update_syscall(struct ptrace_lwpinfo *info);
     void setpid(pid_t pid);

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -137,6 +137,7 @@ protected:
     int protection_fault(int syscall);
 private:
     bool handle_open_call();
+    bool handle_openat_call();
     pid_t pid;
     int handler[MAX_SYSCALL];
     pt_handler_callback callback;
@@ -153,6 +154,7 @@ private:
     pcre2_match_data *re_fs_read_data;
     pcre2_match_context *re_fs_read_context;
     pcre2_jit_stack *re_fs_read_jit;
+    bool do_pcre_match(const char *path);
 #endif
 };
 

--- a/dmoj/cptbox/ptproc.cpp
+++ b/dmoj/cptbox/ptproc.cpp
@@ -1,6 +1,7 @@
 #define _BSD_SOURCE
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -191,9 +192,7 @@ bool pt_process::handle_open_call() {
 
     debugger->freestr(file);
     if (path.empty() || path[0] != '/') {
-        // TODO: handle relative paths in C++.
-        printf("Skip checking relative path: %s\n", path.c_str());
-        return false;
+        path = posixpath::join(debugger->get_fd(AT_FDCWD), path);
     }
     path = posixpath::normpath(path);
 

--- a/dmoj/cptbox/sandbox.py
+++ b/dmoj/cptbox/sandbox.py
@@ -184,8 +184,11 @@ class SecurePopen(six.with_metaclass(SecurePopenMeta, Process)):
                         if not callable(handler):
                             raise ValueError('Handler not callable: ' + handler)
                         self._callbacks[call] = handler
-                        handler = _CALLBACK
+                        handler = getattr(handler, 'with_handler', _CALLBACK)
                     self._handler(call, handler)
+
+            if HAS_PCRE and hasattr(security, 'fs_jail'):
+                self.re_fs_read = utf8bytes(security.fs_jail.pattern)
 
         self._started = threading.Event()
         self._died = threading.Event()

--- a/dmoj/executors/DART.py
+++ b/dmoj/executors/DART.py
@@ -1,7 +1,10 @@
-from .base_executor import ScriptExecutor
+from .base_executor import CompiledExecutor
+from dmoj.executors.mixins import ScriptDirectoryMixin
 
 
-class Executor(ScriptExecutor):
+# Running DART normally results in unholy memory usage
+# Thankfully compiling it results in something...far more sane
+class Executor(ScriptDirectoryMixin, CompiledExecutor):
     ext = '.dart'
     name = 'DART'
     nproc = -1  # Dart uses a really, really large number of threads
@@ -11,8 +14,17 @@ void main() {
     print("echo: Hello, World!");
 }
 '''
-    address_grace = 786432
+    address_grace = 128 * 1024
 
     syscalls = ['epoll_create', 'epoll_ctl', 'epoll_wait', 'timerfd_settime', 'pipe2']
 
     fs = ['.*/vm-service$']
+
+    def get_compile_args(self):
+        return [self.get_command(), '--snapshot=%s' % self.get_compiled_file(), self._code]
+
+    def get_cmdline(self):
+        return [self.get_command(), self.get_compiled_file()]
+
+    def get_executable(self):
+        return self.get_command()

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -113,11 +113,19 @@ class BaseExecutor(PlatformExecutorMixin):
             test_message = b'echo: Hello, World!'
             stdout, stderr = proc.communicate(test_message + b'\n')
 
+            if proc.tle:
+                print(ansi_style('#ansi[Time Limit Exceeded](red|bold)'))
+                return False
+            if proc.mle:
+                print(ansi_style('#ansi[Memory Limit Exceeded](red|bold)'))
+                return False
+
             res = stdout.strip() == test_message and not stderr
             if output:
                 # Cache the versions now, so that the handshake packet doesn't take ages to generate
                 cls.get_runtime_versions()
-                print(ansi_style(['#ansi[Failed](red|bold)', '#ansi[Success](green|bold)'][res]))
+                usage = '[%.3fs, %d KB]' % (proc.execution_time, proc.max_memory)
+                print(ansi_style(['#ansi[Failed](red|bold)', '#ansi[Success](green|bold)'][res]), usage)
             if stdout.strip() != test_message and error_callback:
                 error_callback('Got unexpected stdout output:\n' + utf8text(stdout))
             if stderr:

--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -18,7 +18,7 @@ problem_watches = ()
 env = ConfigNode(defaults={
     'selftest_sandboxing': True,
     'selftest_time_limit': 10,  # 10 seconds
-    'selftest_memory_limit': 65536,  # 64mb of RAM
+    'selftest_memory_limit': 131072,  # 128mb of RAM
     'generator_sandboxing': True,
     'generator_time_limit': 20,  # 20 seconds
     'generator_memory_limit': 524288,  # 512mb of RAM

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ except IOError:
 
 # Allow manually disabling seccomp on old kernels. WSL doesn't have seccomp.
 has_seccomp = not is_wsl and os.environ.get('DMOJ_USE_SECCOMP') != 'no'
+has_pcre = os.environ.get('DMOJ_USE_PCRE') != 'no'
 
 try:
     from Cython.Build import cythonize
@@ -127,6 +128,8 @@ if os.name != 'nt' or 'sdist' in sys.argv:
 
     if has_seccomp:
         libs += ['seccomp']
+    if has_pcre:
+        libs += ['pcre2-8']
     if sys.platform.startswith('freebsd'):
         libs += ['procstat']
 
@@ -139,6 +142,12 @@ if os.name != 'nt' or 'sdist' in sys.argv:
         print('Building without seccomp, expect lower sandbox performance.')
         print('*' * 79)
         macros.append(('PTBOX_NO_SECCOMP', None))
+
+    if not has_pcre:
+        print('*' * 79)
+        print('Building without pcre, expect lower sandbox performance.')
+        print('*' * 79)
+        macros.append(('PTBOX_NO_PCRE', None))
 
     extensions += [Extension('dmoj.cptbox._cptbox', sources=cptbox_sources,
                              language='c++', libraries=libs, define_macros=macros)]

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ class build_ext_dmoj(build_ext, object):
                     print('*' * 79)
             else:
                 extra_compile_args += ['-march=%s' % (target_arch or 'native'), '-O3']
-            self.distribution.ext_modules[0].extra_compile_args = extra_compile_args
+            self.distribution.ext_modules[0].extra_compile_args += extra_compile_args
 
         super(build_ext_dmoj, self).build_extensions()
 
@@ -107,7 +107,7 @@ class build_ext_dmoj(build_ext, object):
 wbox_sources = ['_wbox.pyx', 'handles.cpp', 'process.cpp', 'user.cpp', 'helpers.cpp', 'firewall.cpp']
 cptbox_sources = ['_cptbox.pyx', 'helper.cpp', 'ptdebug.cpp', 'ptdebug_x86.cpp', 'ptdebug_x64.cpp',
                   'ptdebug_x86_on_x64.cpp', 'ptdebug_x32.cpp', 'ptdebug_arm.cpp', 'ptdebug_arm64.cpp',
-                  'ptproc.cpp']
+                  'ptproc.cpp', 'posixpath.cpp']
 
 if not has_pyx:
     wbox_sources[0] = wbox_sources[0].replace('.pyx', '.cpp')
@@ -150,7 +150,8 @@ if os.name != 'nt' or 'sdist' in sys.argv:
         macros.append(('PTBOX_NO_PCRE', None))
 
     extensions += [Extension('dmoj.cptbox._cptbox', sources=cptbox_sources,
-                             language='c++', libraries=libs, define_macros=macros)]
+                             language='c++', libraries=libs, define_macros=macros,
+                             extra_compile_args=['-std=c++11'])]
 
 if os.name != 'nt':
     extensions += [SimpleSharedObject('dmoj.utils.setbufsize', sources=['dmoj/utils/setbufsize.c'])]


### PR DESCRIPTION
To do:

* [x] add basic PCRE support for open-like system calls
* [x] properly handle relative paths (relative to `/proc/$pid/cwd`)
* [x] add support for openat-like system calls with `AT_FDCWD`
* [x] add support for openat-like system calls with arbitrary fds
