### PR TITLE
changed to PollingObserver for network mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ optional arguments:
                         file to load judge configurations from
   -l LOG_FILE, --log-file LOG_FILE
                         log file to use
-  --no-watchdog         disable use of watchdog on problem directories
+  --no-watchdog         disable use of watchdog on problem directories for nfs
+  --polling-observer    use polling observer instead of observer
   -a API_PORT, --api-port API_PORT
                         port to listen for the judge API (do not expose to
                         public, security is left as an exercise for the

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ optional arguments:
   -l LOG_FILE, --log-file LOG_FILE
                         log file to use
   --no-watchdog         disable use of watchdog on problem directories for nfs
-  --polling-observer    use polling observer instead of observer
+  --use-polling-observer    use polling instead of inotify for problem updates
   -a API_PORT, --api-port API_PORT
                         port to listen for the judge API (do not expose to
                         public, security is left as an exercise for the

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ optional arguments:
                         file to load judge configurations from
   -l LOG_FILE, --log-file LOG_FILE
                         log file to use
-  --no-watchdog         disable use of watchdog on problem directories for nfs
+  --no-watchdog         disable use of watchdog on problem directories
   --use-polling-observer    use polling instead of inotify for problem updates
   -a API_PORT, --api-port API_PORT
                         port to listen for the judge API (do not expose to

--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -41,7 +41,7 @@ env = ConfigNode(defaults={
 }, dynamic=False)
 _root = os.path.dirname(__file__)
 
-log_file = server_host = server_port = no_ansi = no_watchdog = problem_regex = case_regex = None
+log_file = server_host = server_port = no_ansi = no_watchdog = polling_observer = problem_regex = case_regex = None
 secure = no_cert_check = False
 cert_store = api_listen = None
 
@@ -56,7 +56,7 @@ def load_env(cli=False, testsuite=False):  # pragma: no cover
     global problem_dirs, only_executors, exclude_executors, log_file, server_host, \
         server_port, no_ansi, no_ansi_emu, env, startup_warnings, no_watchdog, \
         problem_regex, case_regex, api_listen, secure, no_cert_check, cert_store, \
-        problem_watches, cli_command
+        problem_watches, cli_command, polling_observer
 
     if cli:
         description = 'Starts a shell for interfacing with a local judge instance.'
@@ -86,6 +86,8 @@ def load_env(cli=False, testsuite=False):  # pragma: no cover
                                  'security is left as an exercise for the reverse proxy)')
         parser.add_argument('-A', '--api-host', default='127.0.0.1',
                             help='IPv4 address to listen for judge API')
+        parser.add_argument('--polling-observer', action='store_true',
+                            help='use polling observer instead of observer')
 
         if ssl:
             parser.add_argument('-s', '--secure', action='store_true',
@@ -118,6 +120,7 @@ def load_env(cli=False, testsuite=False):  # pragma: no cover
 
     no_ansi = args.no_ansi
     no_watchdog = True if cli else args.no_watchdog
+    polling_observer = False if cli else args.polling_observer
     if not cli:
         api_listen = (args.api_host, args.api_port) if args.api_port else None
 

--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -86,8 +86,8 @@ def load_env(cli=False, testsuite=False):  # pragma: no cover
                                  'security is left as an exercise for the reverse proxy)')
         parser.add_argument('-A', '--api-host', default='127.0.0.1',
                             help='IPv4 address to listen for judge API')
-        parser.add_argument('--polling-observer', action='store_true',
-                            help='use polling observer instead of observer')
+        parser.add_argument('--use-polling-observer', action='store_true',
+                            help='use polling instead of inotify for problem updates')
 
         if ssl:
             parser.add_argument('-s', '--secure', action='store_true',
@@ -120,7 +120,7 @@ def load_env(cli=False, testsuite=False):  # pragma: no cover
 
     no_ansi = args.no_ansi
     no_watchdog = True if cli else args.no_watchdog
-    polling_observer = False if cli else args.polling_observer
+    polling_observer = False if cli else args.use_polling_observer
     if not cli:
         api_listen = (args.api_host, args.api_port) if args.api_port else None
 

--- a/dmoj/monitor.py
+++ b/dmoj/monitor.py
@@ -72,10 +72,11 @@ class Monitor(object):
 
             self._handler = SendProblemsHandler(self._refresher)
             if judgeenv.polling_observer:
-                self._monitor = monitor = PollingObserver()
+                self._monitor = PollingObserver()
             else:
-                self._monitor = monitor = Observer()
+                self._monitor = Observer()
 
+            monitor = self._monitor
             for dir in get_problem_watches():
                 monitor.schedule(self._handler, dir, recursive=True)
                 logger.info('Scheduled for monitoring: %s', dir)

--- a/dmoj/monitor.py
+++ b/dmoj/monitor.py
@@ -8,7 +8,7 @@ from dmoj.judgeenv import get_problem_watches, startup_warnings
 from dmoj.utils.ansi import print_ansi
 
 try:
-    from watchdog.observers import Observer
+    from watchdog.observers.polling import PollingObserver
     from watchdog.events import FileSystemEventHandler
 except ImportError:
     startup_warnings.append('watchdog module not found, install it to automatically update problems')
@@ -70,7 +70,7 @@ class Monitor(object):
                 self._refresher = None
 
             self._handler = SendProblemsHandler(self._refresher)
-            self._monitor = monitor = Observer()
+            self._monitor = monitor = PollingObserver()
             for dir in get_problem_watches():
                 monitor.schedule(self._handler, dir, recursive=True)
                 logger.info('Scheduled for monitoring: %s', dir)

--- a/dmoj/monitor.py
+++ b/dmoj/monitor.py
@@ -8,6 +8,7 @@ from dmoj.judgeenv import get_problem_watches, startup_warnings
 from dmoj.utils.ansi import print_ansi
 
 try:
+    from watchdog.observers import Observer
     from watchdog.observers.polling import PollingObserver
     from watchdog.events import FileSystemEventHandler
 except ImportError:
@@ -70,7 +71,11 @@ class Monitor(object):
                 self._refresher = None
 
             self._handler = SendProblemsHandler(self._refresher)
-            self._monitor = monitor = PollingObserver()
+            if judgeenv.polling_observer:
+                self._monitor = monitor = PollingObserver()
+            else:
+                self._monitor = monitor = Observer()
+
             for dir in get_problem_watches():
                 monitor.schedule(self._handler, dir, recursive=True)
                 logger.info('Scheduled for monitoring: %s', dir)


### PR DESCRIPTION
While using network mounts as problem root the filesystem events don't always get emitted, to detect changes in such cases using ```watchdog.observers.polling.PollingObserver``` instead of the Observer.

Signed-off-by: Kailashnath Nagendran <kailashnath1998@gmail.com>