### PR TITLE
Use direct link to latest release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ install:
   - docker pull "$DOCKER_IMAGE"
   - |
     if [ "$PYTHON_VERSION" != 3.7 ]; then
-      curl -L "$(curl -H "Authorization: token ${GITHUB_API_TOKEN}" -s https://api.github.com/repos/DMOJ/runtimes-python/releases |
-          jq -r '[.[].assets | flatten | .[] | select(.name | startswith("python'"$PYTHON_VERSION-$ARCH"'")) | .browser_download_url][0]')" |
+      curl -L "https://github.com/DMOJ/runtimes-python/releases/latest/download/python$PYTHON_VERSION-$ARCH.tar.gz" |
         tar -xz
     fi
   - >


### PR DESCRIPTION
This unfortunately only works when you know the file name, so it cannot replace the other instances. But this should solve our immediate problems.