### PR TITLE
Restore flake8

### DIFF
--- a/.docker.test.py
+++ b/.docker.test.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import platform
 
 from dmoj import judgeenv

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,18 @@
+name: flake8
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install flake8
+      run: |
+        pip install flake8 flake8-import-order flake8-future-import flake8-commas flake8-logging-format
+    - name: Run flake8
+      run: |
+        flake8 --version
+        flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,6 @@ jobs:
     - env: DMOJ_USE_SECCOMP="yes" PYTHON_VERSION=3.8 ARCH=aarch64 DOCKER_IMAGE=dmoj/runtimes-tier1
       arch: arm64
     - env: DMOJ_USE_SECCOMP="no"  PYTHON_VERSION=3.7 ARCH=amd64 DOCKER_IMAGE=dmoj/runtimes-tier3
-matrix:
-  include:
-  - name: flake8
-    stage: lint
-    language: python
-    python: 3.7
-    env: LINTER="yes"
-    install: pip install flake8 flake8-import-order flake8-future-import flake8-commas flake8-logging-format
-    script:
-      - flake8 --version
-      - flake8
-    after_script:
-stages:
-  - lint
-  - test
 install:
   - docker pull "$DOCKER_IMAGE"
   - |

--- a/dmoj/checkers/linecount.py
+++ b/dmoj/checkers/linecount.py
@@ -1,5 +1,5 @@
 from re import split as resplit
-from typing import Callable, Union
+from typing import Union
 
 from dmoj.result import CheckerResult
 from dmoj.utils.unicode import utf8bytes

--- a/dmoj/executors/V8JS.py
+++ b/dmoj/executors/V8JS.py
@@ -12,6 +12,6 @@ class Executor(ScriptExecutor):
     @classmethod
     def get_version_flags(cls, command):
         return [('-e', 'print(version())')]
-    
+
     def get_cmdline(self):
-        return [self.get_command(), '--stack-size=131072', self._code] # 128MB Stack Limit
+        return [self.get_command(), '--stack-size=131072', self._code]  # 128MB Stack Limit


### PR DESCRIPTION
Travis linting is fixed, but I don't know if it is really necessary. Linting on Travis allows builds to fail early, which might be good, but also adds an extra minute to Travis since it can't be parallelized this way.