### PR TITLE
Fix `compile_with_auxiliary_files`

### DIFF
--- a/dmoj/checkers/bridged.py
+++ b/dmoj/checkers/bridged.py
@@ -8,17 +8,15 @@ from dmoj.result import CheckerResult
 from dmoj.utils.helper_files import compile_with_auxiliary_files, mktemp
 from dmoj.utils.unicode import utf8text
 
-executor = None
 
+def get_executor(problem_id, files, flags, lang, compiler_time_limit, should_cache):
+    if isinstance(files, str):
+        filenames = [files]
+    elif isinstance(files.unwrap(), list):
+        filenames = list(files.unwrap())
 
-def get_executor(files, lang, compiler_time_limit, problem_id):
-    global executor
-
-    if executor is None:
-        if not isinstance(files, list):
-            files = [files]
-        filenames = [os.path.join(get_problem_root(problem_id), f) for f in files]
-        executor = compile_with_auxiliary_files(filenames, lang, compiler_time_limit)
+    filenames = [os.path.join(get_problem_root(problem_id), f) for f in filenames]
+    executor = compile_with_auxiliary_files(filenames, flags, lang, compiler_time_limit, should_cache)
 
     return executor
 
@@ -34,11 +32,13 @@ def check(
     memory_limit=env['generator_memory_limit'],
     compiler_time_limit=env['generator_compiler_limit'],
     feedback=True,
+    flags=[],
+    cached=True,
     type='default',
     point_value=None,
     **kwargs
 ) -> CheckerResult:
-    executor = get_executor(files, lang, compiler_time_limit, problem_id)
+    executor = get_executor(problem_id, files, flags, lang, compiler_time_limit, cached)
 
     if type not in contrib_modules:
         raise InternalError('%s is not a valid return code parser' % type)

--- a/dmoj/generator.py
+++ b/dmoj/generator.py
@@ -4,6 +4,6 @@ from dmoj.utils.helper_files import compile_with_auxiliary_files
 
 
 class GeneratorManager:
-    def get_generator(self, filenames, flags, lang=None, compiler_time_limit=None):
+    def get_generator(self, filenames, flags, lang=None, compiler_time_limit=None, should_cache=True):
         filenames = list(map(os.path.abspath, filenames))
-        return compile_with_auxiliary_files(filenames, lang, compiler_time_limit)
+        return compile_with_auxiliary_files(filenames, flags, lang, compiler_time_limit, should_cache)

--- a/dmoj/graders/bridged.py
+++ b/dmoj/graders/bridged.py
@@ -79,7 +79,13 @@ class BridgedInteractiveGrader(StandardGrader):
 
     def _generate_interactor_binary(self):
         files = self.handler_data.files
-        if not isinstance(files, list):
-            files = [files]
-        files = [os.path.join(get_problem_root(self.problem.id), f) for f in files]
-        return compile_with_auxiliary_files(files, self.handler_data.lang, self.handler_data.compiler_time_limit)
+        if isinstance(files, str):
+            filenames = [files]
+        elif isinstance(files.unwrap(), list):
+            filenames = list(files.unwrap())
+        filenames = [os.path.join(get_problem_root(self.problem.id), f) for f in filenames]
+        flags = self.handler_data.get('flags', [])
+        should_cache = self.handler_data.get('cached', True)
+        return compile_with_auxiliary_files(
+            filenames, flags, self.handler_data.lang, self.handler_data.compiler_time_limit, should_cache
+        )

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -248,6 +248,7 @@ class TestCase:
         time_limit = env.generator_time_limit
         memory_limit = env.generator_memory_limit
         compiler_time_limit = env.generator_compiler_time_limit
+        should_cache = True
         lang = None  # Default to C/C++
 
         base = get_problem_root(self.problem.id)
@@ -271,6 +272,7 @@ class TestCase:
             time_limit = gen.time_limit or time_limit
             memory_limit = gen.memory_limit or memory_limit
             compiler_time_limit = gen.compiler_time_limit or compiler_time_limit
+            should_cache = gen.get('cached', True)
             lang = gen.language
 
         if not isinstance(filenames, list):
@@ -278,7 +280,7 @@ class TestCase:
 
         filenames = [os.path.join(base, name) for name in filenames]
         executor = self.problem.generator_manager.get_generator(
-            filenames, flags, lang=lang, compiler_time_limit=compiler_time_limit
+            filenames, flags, lang=lang, compiler_time_limit=compiler_time_limit, should_cache=should_cache
         )
 
         # convert all args to str before launching; allows for smoother int passing


### PR DESCRIPTION
* Allows for passing of flags to generators and bridged checkers
* Allows for generators and bridged checkers to be not cached
* Fixes regression with bridged checker introduced in 0c08757
* Convert `dmoj.utils.aux_files` to Unix line endings