### PR TITLE
Turn on --release-safe mode for Zig

### DIFF
--- a/dmoj/executors/ZIG.py
+++ b/dmoj/executors/ZIG.py
@@ -25,6 +25,7 @@ pub fn main() !void {
             self.get_command(),
             'build-exe',
             self._code,
+            '--release-safe',
             '--name',
             self.problem,
         ]


### PR DESCRIPTION
This is equivalent to -O2 in C compilers