### PR TITLE
make the \r in zig go bye bye

### DIFF
--- a/dmoj/executors/ZIG.py
+++ b/dmoj/executors/ZIG.py
@@ -21,6 +21,8 @@ pub fn main() !void {
 }'''
 
     def __init__(self, problem_id, source_code, **kwargs):
+        # this clean needs to happen because zig refuses to compile carriage returns
+        # https://github.com/ziglang/zig/issues/544
         code = source_code.replace(b'\r\n', b'\r').replace(b'\r', b'\n')
         super().__init__(problem_id, code, **kwargs)
 

--- a/dmoj/executors/ZIG.py
+++ b/dmoj/executors/ZIG.py
@@ -20,6 +20,10 @@ pub fn main() !void {
     }
 }'''
 
+    def __init__(self, problem_id, source_code, **kwargs):
+        code = source_code.replace(b'\r\n', b'\r').replace(b'\r', b'\n')
+        super().__init__(problem_id, code, **kwargs)
+
     def get_compile_args(self):
         return [
             self.get_command(),


### PR DESCRIPTION
Zig will not compile because ace wants `\r\n`! 

https://github.com/ziglang/zig/issues/544

me: psh I don't need to end to end test what could possibly go wrong
zig: haha strictness machine go brrrr