### PR TITLE
cptbox: validate null file paths

### DIFF
--- a/dmoj/cli.py
+++ b/dmoj/cli.py
@@ -74,14 +74,14 @@ def cli_main():
 
     judgeenv.load_env(cli=True)
 
+    logging.basicConfig(
+        filename=judgeenv.log_file, level=logging.INFO, format='%(levelname)s %(asctime)s %(module)s %(message)s'
+    )
+
     executors.load_executors()
     contrib.load_contrib_modules()
 
     print('Running local judge...')
-
-    logging.basicConfig(
-        filename=judgeenv.log_file, level=logging.INFO, format='%(levelname)s %(asctime)s %(module)s %(message)s'
-    )
 
     judge = LocalJudge()
 

--- a/dmoj/cptbox/_cptbox.pyx
+++ b/dmoj/cptbox/_cptbox.pyx
@@ -306,7 +306,7 @@ cdef class Debugger:
 
     def readstr(self, unsigned long address, size_t max_size=4096):
         cdef char* str = self.thisptr.readstr(address, max_size)
-        pystr = <object>str
+        pystr = <object>str if str != NULL else None
         self.thisptr.freestr(str)
         return pystr
 

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -196,7 +196,7 @@ protected:
     void *on_return_context;
     int execve_id;
     std::map<pid_t, int> syscall_;
-    static bool use_peekdata;
+    bool use_peekdata = false;
     virtual char *readstr_peekdata(unsigned long addr, size_t max_size);
 #if PTBOX_FREEBSD
     linux_pt_reg bsd_converted_regs;

--- a/dmoj/cptbox/tracer.py
+++ b/dmoj/cptbox/tracer.py
@@ -75,7 +75,8 @@ class AdvancedDebugger(Debugger):
         if self.address_bits == 32:
             address &= 0xFFFFFFFF
         try:
-            return utf8text(super().readstr(address, max_size))
+            read = super().readstr(address, max_size)
+            return utf8text(read) if read else None
         except UnicodeDecodeError:
             # It's possible for the text to crash utf8text, but this would mean a
             # deliberate attack, so we kill the process here instead


### PR DESCRIPTION
Otherwise, we can end up failing ptrace PEEKDATA, and return a garbage
path that only fails the sandbox check by accident.