### PR TITLE
judgeenv: only treat directories with init.yml as problems

### DIFF
--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -192,10 +192,12 @@ _problem_root_cache: Dict[str, str] = {}
 
 
 def get_problem_root(problem_id):
-    if problem_id not in _problem_root_cache or not os.path.isdir(_problem_root_cache[problem_id]):
+    cached_root = _problem_root_cache.get(problem_id)
+    if cached_root is None or not os.path.isfile(os.path.join(cached_root, 'init.yml')):
         for root_dir in get_problem_roots():
             problem_root_dir = os.path.join(root_dir, problem_id)
-            if os.path.isdir(problem_root_dir):
+            problem_init = os.path.join(problem_root_dir, 'init.yml')
+            if os.path.isfile(problem_init):
                 _problem_root_cache[problem_id] = problem_root_dir
                 break
 


### PR DESCRIPTION
This should prevent issues with flaky NFS / syncing when moving problem
directories, which has sometimes left hanging problem directories in
connected judges (but no init.yml files).

This then leads to errors like

```
dmoj.config.InvalidInitException: 'file "init.yml" could not be found in "/problems/site/dmopc19c7p1"'
```

...that shouldn't happen, since there is a problem directory with that code that _does_ contain an `init.yml`, elsewhere.

Ideally hanging directories shouldn't happen in the first place, but accepting a universe where they do, not failing on our end is the next best thing.