### PR TITLE
packet: cleanly exit judge on write failure

### DIFF
--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -259,13 +259,15 @@ class Judge:
 
             message = ''.join(traceback.format_exception(*sys.exc_info()))
 
-        # Strip ANSI from the message, since this might be a checker's CompileError ...we don't want to see the raw ANSI
-        # codes from GCC/Clang on the site. We could use format_ansi and send HTML to the site, but the site doesn't
-        # presently support HTML internal error formatting.
-        self.packet_manager.internal_error_packet(strip_ansi(message))
+        logger.error(message)
 
-        # Logs can contain ANSI, and it'll display fine
-        print(message, file=sys.stderr)
+        try:
+            # Strip ANSI from the message, since this might be a checker's CompileError ...we don't want to see the raw
+            # ANSI codes from GCC/Clang on the site. We could use format_ansi and send HTML to the site, but the site
+            # doesn't presently support HTML internal error formatting.
+            self.packet_manager.internal_error_packet(strip_ansi(message))
+        except Exception:  # noqa E722: don't want `log_internal_error` to trigger `log_internal_error`, ever
+            logger.exception('Error encountered while reporting error to site!')
 
 
 class JudgeWorker:


### PR DESCRIPTION
We already handle the case where we fail on recv, which is more likely.

Fixes #685.