### PR TITLE
Provide launch kwargs to executor `get_cmdline`

### DIFF
--- a/dmoj/executors/AWK.py
+++ b/dmoj/executors/AWK.py
@@ -9,7 +9,7 @@ class Executor(ScriptExecutor):
     syscalls = ['getgroups']  # gawk is annoying.
     test_program = '{ print $0 }'
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), '-f', self._code]
 
     @classmethod

--- a/dmoj/executors/BASH.py
+++ b/dmoj/executors/BASH.py
@@ -7,5 +7,5 @@ class Executor(ShellExecutor):
     command = 'bash'
     test_program = 'exec cat'
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return ['bash', self._code]

--- a/dmoj/executors/COFFEE.py
+++ b/dmoj/executors/COFFEE.py
@@ -35,7 +35,7 @@ process.stdin.on 'readable', () ->
             return False
         return super().initialize()
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), self.runtime_dict['coffee'], self._code]
 
     def get_fs(self):

--- a/dmoj/executors/DART.py
+++ b/dmoj/executors/DART.py
@@ -22,7 +22,7 @@ void main() {
     def get_compile_args(self):
         return [self.get_command(), '--snapshot=%s' % self.get_compiled_file(), self._code]
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), self.get_compiled_file()]
 
     def get_executable(self):

--- a/dmoj/executors/FORTH.py
+++ b/dmoj/executors/FORTH.py
@@ -13,5 +13,5 @@ HELLO
 '''
     fs = [r'/\.gforth-history$']
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), self._code, '-e', 'bye']

--- a/dmoj/executors/GROOVY.py
+++ b/dmoj/executors/GROOVY.py
@@ -24,7 +24,7 @@ println System.in.newReader().readLine()
         super().create_files(problem_id, source_code, *args, **kwargs)
         self._class_name = problem_id
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         res = super().get_cmdline()
 
         res[-2:-1] = ['-Dsubmission.file=%s' % self._class_name] + self.runtime_dict['groovy_args']

--- a/dmoj/executors/KOTLIN.py
+++ b/dmoj/executors/KOTLIN.py
@@ -25,8 +25,8 @@ fun main(args: Array<String>) {
         super().create_files(problem_id, source_code, *args, **kwargs)
         self._jar_name = '%s.jar' % problem_id
 
-    def get_cmdline(self):
-        res = super().get_cmdline()
+    def get_cmdline(self, **kwargs):
+        res = super().get_cmdline(**kwargs)
         res[-2:] = ['-jar', self._jar_name]
         return res
 

--- a/dmoj/executors/PERL.py
+++ b/dmoj/executors/PERL.py
@@ -9,5 +9,5 @@ class Executor(ScriptExecutor):
     test_program = 'print<>'
     syscalls = ['umtx_op']
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return ['perl', '-Mre=eval', self._code]

--- a/dmoj/executors/PHP.py
+++ b/dmoj/executors/PHP.py
@@ -11,5 +11,5 @@ class Executor(ScriptExecutor):
 
     test_program = '<?php while($f = fgets(STDIN)) echo $f;'
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return ['php', self._code]

--- a/dmoj/executors/PRO.py
+++ b/dmoj/executors/PRO.py
@@ -21,5 +21,5 @@ class Executor(ScriptExecutor):
     :- main.
 '''
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), '--goal=main', '-c', self._code]

--- a/dmoj/executors/RKT.py
+++ b/dmoj/executors/RKT.py
@@ -25,7 +25,7 @@ class Executor(ScriptDirectoryMixin, CompiledExecutor):
     def get_compile_args(self):
         return [self.runtime_dict['raco'], 'make', self._code]
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), self._code]
 
     def get_executable(self):

--- a/dmoj/executors/RUBY2.py
+++ b/dmoj/executors/RUBY2.py
@@ -26,7 +26,7 @@ class Executor(ScriptExecutor):
                 components.pop()
         return fs
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), '--disable-gems', self._code]
 
     @classmethod

--- a/dmoj/executors/SBCL.py
+++ b/dmoj/executors/SBCL.py
@@ -23,11 +23,11 @@ class Executor(NullStdoutMixin, ScriptDirectoryMixin, CompiledExecutor):
     def get_compile_args(self):
         return [self.get_command(), '--eval', self.compile_script.format(code=self._code), '--quit']
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [
             self.get_command(),
             '--dynamic-space-size',
-            str(int(self.__memory_limit / 1024.0 + 1)),
+            str(int(kwargs['memory'] / 1024.0 + 1)),
             '--noinform',
             '--no-sysinit',
             '--no-userinit',
@@ -36,10 +36,6 @@ class Executor(NullStdoutMixin, ScriptDirectoryMixin, CompiledExecutor):
             '--quit',
             '--end-toplevel-options',
         ]
-
-    def launch(self, *args, **kwargs):
-        self.__memory_limit = kwargs['memory']
-        return super().launch(*args, **kwargs)
 
     def get_executable(self):
         return self.get_command()

--- a/dmoj/executors/SCALA.py
+++ b/dmoj/executors/SCALA.py
@@ -28,8 +28,8 @@ object self_test extends App {
         super().create_files(problem_id, source_code, *args, **kwargs)
         self._class_name = problem_id
 
-    def get_cmdline(self):
-        res = super().get_cmdline()
+    def get_cmdline(self, **kwargs):
+        res = super().get_cmdline(**kwargs)
 
         # Simply run bash -x $(which scala) and copy all arguments after -Xmx and -Xms
         # and add it as a list in the configuration.

--- a/dmoj/executors/SED.py
+++ b/dmoj/executors/SED.py
@@ -7,7 +7,7 @@ class Executor(ScriptExecutor):
     command = 'sed'
     test_program = 's/^//'
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), '-f', self._code]
 
     @classmethod

--- a/dmoj/executors/TUR.py
+++ b/dmoj/executors/TUR.py
@@ -21,7 +21,7 @@ put echo
         tprologc = self.runtime_dict['tprologc']
         return [tprologc, self._code, os.path.dirname(tprologc)]
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.runtime_dict['tprolog'], self._code + 'bc']
 
     def get_executable(self):

--- a/dmoj/executors/V8JS.py
+++ b/dmoj/executors/V8JS.py
@@ -13,5 +13,5 @@ class Executor(ScriptExecutor):
     def get_version_flags(cls, command):
         return [('-e', 'print(version())')]
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return [self.get_command(), '--stack-size=131072', self._code]  # 128MB Stack Limit

--- a/dmoj/executors/asm_executor.py
+++ b/dmoj/executors/asm_executor.py
@@ -83,7 +83,7 @@ class ASMExecutor(CompiledExecutor):
         self._executable = executable
         return executable
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         if self.use_qemu:
             return [self.qemu_path, self._executable]
         return super().get_cmdline()

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -84,7 +84,7 @@ class BaseExecutor(PlatformExecutorMixin):
     def get_executable(self) -> Optional[str]:
         return None
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         raise NotImplementedError()
 
     def get_nproc(self) -> int:

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -251,7 +251,7 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
         self._executable = self.get_compiled_file()
         return self._executable
 
-    def get_cmdline(self) -> List[str]:
+    def get_cmdline(self, **kwargs) -> List[str]:
         return [self.problem]
 
     def get_executable(self) -> str:

--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -74,7 +74,7 @@ class JavaExecutor(CompiledExecutor):
     def get_executable(self):
         return self.get_vm()
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         agent_flags = '-javaagent:%s=policy:%s' % (self._agent_file, self._policy_file)
         for hint in self._hints:
             agent_flags += ',%s' % hint
@@ -86,15 +86,14 @@ class JavaExecutor(CompiledExecutor):
             self.get_vm_mode(),
             agent_flags,
             '-Xss128m',
-            '-Xmx%dK' % self.__memory_limit,
+            '-Xmx%dK' % kwargs['orig_memory'],
             '-XX:+UseSerialGC',
             '-XX:ErrorFile=submission_jvm_crash.log',
             self._class_name,
         ]
 
     def launch(self, *args, **kwargs):
-        self.__memory_limit = kwargs['memory']
-        kwargs['memory'] = 0
+        kwargs['orig_memory'], kwargs['memory'] = kwargs['memory'], 0
         return super().launch(*args, **kwargs)
 
     def launch_unsafe(self, *args, **kwargs):

--- a/dmoj/executors/mixins.py
+++ b/dmoj/executors/mixins.py
@@ -114,7 +114,7 @@ class PlatformExecutorMixin(metaclass=abc.ABCMeta):
         env.update(self.get_env())
 
         return TracedPopen(
-            [utf8bytes(a) for a in self.get_cmdline() + list(args)],
+            [utf8bytes(a) for a in self.get_cmdline(**kwargs) + list(args)],
             executable=utf8bytes(self.get_executable()),
             security=self.get_security(launch_kwargs=kwargs),
             address_grace=self.get_address_grace(),

--- a/dmoj/executors/mono_executor.py
+++ b/dmoj/executors/mono_executor.py
@@ -57,7 +57,7 @@ class MonoExecutor(CompiledExecutor):
     def get_compiled_file(self):
         return self._file('%s.exe' % self.problem)
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         return ['mono', self._executable]
 
     def get_executable(self):

--- a/dmoj/executors/python_executor.py
+++ b/dmoj/executors/python_executor.py
@@ -28,7 +28,7 @@ runpy.run_path(sys.argv[0], run_name='__main__')
     def get_compile_args(self):
         return [self.get_command(), '-m', 'compileall', '-q', self._dir]
 
-    def get_cmdline(self):
+    def get_cmdline(self, **kwargs):
         # -B: Don't write .pyc/.pyo, since sandbox will kill those writes
         # -S: Disable site module for speed (no loading dist-packages nor site-packages)
         return [self.get_command(), '-BS' + ('u' if self.unbuffered else ''), self._loader, self._code]

--- a/dmoj/executors/script_executor.py
+++ b/dmoj/executors/script_executor.py
@@ -33,7 +33,7 @@ class ScriptExecutor(BaseExecutor):
         with open(self._code, 'wb') as fo:
             fo.write(utf8bytes(source_code))
 
-    def get_cmdline(self) -> List[str]:
+    def get_cmdline(self, **kwargs) -> List[str]:
         command = self.get_command()
         assert command is not None
         return [command, self._code]


### PR DESCRIPTION
This removes the need for ugly hacks like caching the current
invocation's values in `launch`.