### PR TITLE
Kill the judging submission first with a keyboard interrupt on CLI

### DIFF
--- a/dmoj/commands/resubmit.py
+++ b/dmoj/commands/resubmit.py
@@ -47,8 +47,11 @@ class ResubmitCommand(Command):
 
         self.judge.submission_id_counter += 1
         self.judge.graded_submissions.append((problem_id, lang, src, tl, ml))
-        self.judge.begin_grading(
-            Submission(self.judge.submission_id_counter, problem_id, lang, src, tl, ml, False, {}),
-            blocking=True,
-            report=print,
-        )
+        try:
+            self.judge.begin_grading(
+                Submission(self.judge.submission_id_counter, problem_id, lang, src, tl, ml, False, {}),
+                blocking=True,
+                report=print,
+            )
+        except KeyboardInterrupt:
+            self.judge.abort_grading()

--- a/dmoj/commands/submit.py
+++ b/dmoj/commands/submit.py
@@ -73,10 +73,13 @@ class SubmitCommand(Command):
 
         self.judge.submission_id_counter += 1
         self.judge.graded_submissions.append((problem_id, language_id, src, time_limit, memory_limit))
-        self.judge.begin_grading(
-            Submission(
-                self.judge.submission_id_counter, problem_id, language_id, src, time_limit, memory_limit, False, {}
-            ),
-            blocking=True,
-            report=print,
-        )
+        try:
+            self.judge.begin_grading(
+                Submission(
+                    self.judge.submission_id_counter, problem_id, language_id, src, time_limit, memory_limit, False, {}
+                ),
+                blocking=True,
+                report=print,
+            )
+        except KeyboardInterrupt:
+            self.judge.abort_grading()


### PR DESCRIPTION
This is more of a QOL improvement. Currently, when there is a long running submission (e.g a submission that TLEs on every case), there is no way to abort the submission. Pressing `Ctrl-C` would kill the CLI, potentially losing any commands that were previously typed and had scrolled off the screen (since there is no persistent history). Thus, the only way would be to wait out the grading.

In this PR, instead of killing the CLI directly while a submission is grading, we first kill the currently grading submission if there is one.