### PR TITLE
Added COCI ContribModule for fraction of points in bridged checker

### DIFF
--- a/dmoj/contrib/coci.py
+++ b/dmoj/contrib/coci.py
@@ -1,0 +1,26 @@
+import re
+
+from dmoj.contrib.testlib import ContribModule as TestlibContribModule
+from dmoj.error import InternalError
+from dmoj.result import CheckerResult
+
+
+class ContribModule(TestlibContribModule):
+    name = 'coci'
+    repartial = re.compile(br'^partial ((\d+)\/(\d*[1-9]\d*))\n$')
+
+    @classmethod
+    def parse_return_code(cls, proc, executor, point_value, time_limit, memory_limit, feedback, name, stderr):
+        if proc.returncode == cls.PARTIAL:
+            match = cls.repartial.search(stderr)
+            if not match:
+                raise InternalError('Invalid stderr for fraction of points: %r' % stderr)
+            percentage = int(match.group(2)) / int(match.group(3))
+            if not 0.0 <= percentage <= 1.0:
+                raise InternalError('Invalid fraction: %s' % match.group(1))
+            points = percentage * point_value
+            return CheckerResult(True, points, feedback=feedback)
+        else:
+            return super().parse_return_code(
+                proc, executor, point_value, time_limit, memory_limit, feedback, name, stderr
+            )


### PR DESCRIPTION
ContribModule for COCI style problems, which often specify a fraction of points earned for a subtask. For example: https://dmoj.ca/problem/coci19c6p4.

This uses testlib return codes, and supports fractions in the range [0, 1]. Similar to the [testlib ContribModule](https://github.com/DMOJ/judge-server/blob/master/dmoj/contrib/testlib.py), the fraction is outputted to stderr in the form `partial n/d`, where `n` is a non negative integer specifying the numerator, and `d` is a positive integer specifying the denominator. This fraction represents the fraction of points earned for that subtask.  For example, if the subtask is worth 10 points, and the output to stderr is `partial 1/3` (with return code 7), then 3.3333... points are earned for that subtask.