### PR TITLE
ipc: trim submission output before sending to controller

### DIFF
--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -443,6 +443,10 @@ class JudgeWorker:
                         # past).
                         is_short_circuiting |= batch_number is not None or is_short_circuiting_enabled
 
+                # Legacy hack: we need to allow graders to read and write `proc_output` on the `Result` object, but the
+                # judge controller only cares about the trimmed output, and shouldn't waste memory buffering the full
+                # output. So, we trim it here so we don't run out of memory in the controller.
+                result.proc_output = result.output
                 yield IPC.RESULT, (batch_number, case_number, result)
 
             if batch_number:


### PR DESCRIPTION
Otherwise, the controller can run out of RAM buffering testcase updates.