### PR TITLE
Revert "Revert "Stop using jemalloc in Docker""

### DIFF
--- a/.docker/entry
+++ b/.docker/entry
@@ -4,7 +4,6 @@ export DMOJ_IN_DOCKER=1
 export PYTHONUNBUFFERED=1
 export LANG=C.UTF-8
 export PYTHONIOENCODING=utf8
-export LD_PRELOAD="$(jemalloc-config --libdir)/libjemalloc.so.$(jemalloc-config --revision)"
 
 cd /judge
 pip3 install -q -e .


### PR DESCRIPTION
This reverts commit b43e4a275d93f0f2bfda76229c10ba73458ff697.

The underlying issue that kept blowing up memory fragmentation even
post-IPC-judge-rewrite was fixed in e1a9b23, and glibc malloc has a
slightly smaller baseline memory footprint.