### PR TITLE
Remove message about aborting not deleting files

### DIFF
--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -208,7 +208,7 @@ class Judge:
 
     def _ipc_grading_aborted(self, report) -> None:
         self.packet_manager.submission_aborted_packet()
-        report(ansi_style('#ansi[Forcefully terminating grading. Temporary files may not be deleted.](red|bold)'))
+        report(ansi_style('#ansi[Forcefully terminating grading.]red|bold)'))
 
     def _ipc_unhandled_exception(self, _report, message: str) -> None:
         logger.error("Unhandled exception in worker process")


### PR DESCRIPTION
It seems that after #673, temporary files are deleted after a submission aborts. Since the submission is run on a separate process now, the GC will cleanup any temporary files. Thus, the message `Temporary files may not be deleted.` is only partially correct, since temporary files are now _always_ deleted.

This PR removes the message.