### PR TITLE
cptbox: construct empty filter when executing x86-on-x64

### DIFF
--- a/dmoj/cptbox/helper.cpp
+++ b/dmoj/cptbox/helper.cpp
@@ -137,30 +137,34 @@ int cptbox_child_run(const struct child_config *config) {
         scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_TRACE(0));
         if (!ctx) {
             fprintf(stderr, "Failed to initialize seccomp context!");
-            return 203;
+            goto seccomp_fail;
         }
-
-        unsigned int child_arch = get_seccomp_arch(config->debugger_type);
 
         int rc;
-        if (seccomp_arch_exist(ctx, child_arch) == -EEXIST &&
-            (rc = seccomp_arch_add(ctx, child_arch)) != 0) {
-            fprintf(stderr, "seccomp_arch_add: %s\n", strerror(-rc));
-            return 203;
-        }
-
-        for (int syscall = 0; syscall < MAX_SYSCALL; syscall++) {
-            if (config->syscall_whitelist[syscall]) {
-                if (rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, syscall, 0)) {
-                    fprintf(stderr, "seccomp_rule_add(..., %d): %s\n", syscall, strerror(-rc));
-                    // This failure is not fatal, it'll just cause the syscall to trap anyway.
+        unsigned int child_arch = get_seccomp_arch(config->debugger_type);
+        if (child_arch != seccomp_arch_native()) {
+            if ((rc = seccomp_arch_add(ctx, child_arch))) {
+                fprintf(stderr, "seccomp_arch_add: %s\n", strerror(-rc));
+                goto seccomp_fail;
+            }
+            // FIXME(tbrindus): do nothing else for now. The seccomp filter will
+            // be empty and trap on every syscall. Pending
+            //   https://github.com/seccomp/libseccomp/issues/259
+            // or plumbing libseccomp pseudosyscall mapping up to here.
+        } else {
+            for (int syscall = 0; syscall < MAX_SYSCALL; syscall++) {
+                if (config->syscall_whitelist[syscall]) {
+                    if ((rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, syscall, 0))) {
+                        fprintf(stderr, "seccomp_rule_add(..., %d): %s\n", syscall, strerror(-rc));
+                        // This failure is not fatal, it'll just cause the syscall to trap anyway.
+                    }
                 }
             }
         }
 
-        if (rc = seccomp_load(ctx)) {
+        if ((rc = seccomp_load(ctx))) {
             fprintf(stderr, "seccomp_load: %s\n", strerror(-rc));
-            return 203;
+            goto seccomp_fail;
         }
 
         seccomp_release(ctx);
@@ -194,6 +198,9 @@ int cptbox_child_run(const struct child_config *config) {
     execve(config->file, config->argv, config->envp);
     perror("execve");
     return 205;
+
+seccomp_fail:
+    return 203;
 }
 
 // From python's _posixsubprocess


### PR DESCRIPTION
This trades performance for security, as the original code went through
libseccomp syscall translation and did not allow the correct syscalls.