### PR TITLE
executors: tag submission tempdir with submission ID where available

### DIFF
--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -40,11 +40,13 @@ class BaseExecutor(PlatformExecutorMixin):
         problem_id: str,
         source_code: bytes,
         dest_dir: Optional[str] = None,
+        tempdir_tag: Optional[str] = None,
         hints: Optional[List[str]] = None,
         unbuffered: bool = False,
         **kwargs
     ):
         self._tempdir = dest_dir or env.tempdir
+        self._tempdir_tag = tempdir_tag
         self._dir = None
         self.problem = problem_id
         self.source = source_code
@@ -79,7 +81,9 @@ class BaseExecutor(PlatformExecutorMixin):
         # Defer creation of temporary submission directory until first file is created,
         # because we may not need one (e.g. for cached executors).
         if self._dir is None:
-            self._dir = tempfile.mkdtemp(dir=self._tempdir)
+            self._dir = tempfile.mkdtemp(
+                dir=self._tempdir, suffix='-%s' % self._tempdir_tag if self._tempdir_tag else None
+            )
         return os.path.join(self._dir, *paths)
 
     @classmethod

--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -114,6 +114,7 @@ class StandardGrader(BaseGrader):
         return executors[self.language].Executor(
             self.problem.id,
             self.source,
+            tempdir_tag=str(self.judge.submission.id),
             hints=self.problem.config.hints or [],
             unbuffered=self.problem.config.unbuffered,
         )


### PR DESCRIPTION
This will help tracking down obscure bugs where processes linger despite
their directories having been long removed.