### PR TITLE
Check `custom_judge` first before other graders

### DIFF
--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -163,12 +163,12 @@ class Problem:
     def grader_class(self):
         from dmoj import graders
 
-        if 'signature_grader' in self.config:
+        if 'custom_judge' in self.config:
+            return graders.CustomGrader
+        elif 'signature_grader' in self.config:
             return graders.SignatureGrader
         elif 'interactive' in self.config:
             return graders.BridgedInteractiveGrader
-        elif 'custom_judge' in self.config:
-            return graders.CustomGrader
         else:
             return graders.StandardGrader
 


### PR DESCRIPTION
This will allow graders to inherit from e.g
`BridgedInteractiveGrader` without doing sketchy things with
the problem config. Currently, `BridgedInteractiveGrader` is used
if the `interactive` key is in the problem dictionary, while
it is also accessed in that grader's constructor. This gives
no easy way to inherit from this grader without touching the
problem config or Python's internals.