### PR TITLE
contrib: Correct inaccuracies in PEG contrib module 

### DIFF
--- a/dmoj/checkers/bridged.py
+++ b/dmoj/checkers/bridged.py
@@ -68,7 +68,7 @@ def check(
             point_value,
             time_limit,
             memory_limit,
-            feedback=utf8text(proc_output) if feedback else None,
+            feedback=utf8text(proc_output) if feedback else '',
             name='checker',
             stderr=error,
         )

--- a/dmoj/contrib/peg.py
+++ b/dmoj/contrib/peg.py
@@ -1,5 +1,3 @@
-import re
-
 from dmoj.contrib.default import ContribModule as DefaultContribModule
 from dmoj.result import CheckerResult
 from dmoj.utils.helper_files import parse_helper_file_error
@@ -7,24 +5,28 @@ from dmoj.utils.helper_files import parse_helper_file_error
 
 class ContribModule(DefaultContribModule):
     name = 'peg'
-    repartial = re.compile(r'^(\d+)\n(\d+)$', re.M)
 
     @classmethod
     def get_checker_args_format_string(cls):
-        return '{output_file} {answer_file} {input_file}'
+        return '{answer_file} {output_file} {input_file}'
 
     @classmethod
     def parse_return_code(cls, proc, executor, point_value, time_limit, memory_limit, feedback, name, stderr):
         if proc.returncode == cls.AC:
             return True
         elif proc.returncode == cls.WA:
-            # So for some reason, PEG doesn't have a separate return code for partials
-            match = cls.repartial.search(feedback)
-            if match:
-                # We like to return _AC for partials, vs PEG and WA
-                percentage = int(match.group(1)) / int(match.group(2))
-                if percentage:
-                    return CheckerResult(True, point_value * percentage)
+            # PEG allows for a ratio of floating points
+            # Scanning for floating points with a regex is impractical, so we loop all lines
+            feedback_lines = feedback.split('\n')
+            for line1, line2 in zip(feedback_lines, feedback_lines[1:]):
+                try:
+                    percentage = float(line1) / float(line2)
+                except (ValueError, ZeroDivisionError):
+                    pass
+                else:
+                    if percentage > 0:
+                        # We like to return _AC for partials, vs PEG and WA
+                        return CheckerResult(True, point_value * percentage)
             return False
         else:
             parse_helper_file_error(proc, executor, name, stderr, time_limit, memory_limit)

--- a/dmoj/graders/bridged.py
+++ b/dmoj/graders/bridged.py
@@ -34,7 +34,7 @@ class BridgedInteractiveGrader(StandardGrader):
             case.points,
             self._interactor_time_limit,
             self._interactor_memory_limit,
-            feedback=utf8text(stderr) if self.handler_data.feedback else None,
+            feedback=utf8text(stderr) if self.handler_data.feedback else '',
             name='interactor',
             stderr=stderr,
         )


### PR DESCRIPTION
According to @t3nsor, the correct order is `<checker> <judge answer> <program output> <input> <source file>`. (I suspect we can get away with not passing the source file in 99% of cases)

Additionally, printing a ratio of floats is valid.

NOI '04 P1 (which I based this code off of) just happened to have poor choice in variable names...