### PR TITLE
Add flag to allow siggrader to not overwrite main function; fixes #730

### DIFF
--- a/dmoj/graders/signature.py
+++ b/dmoj/graders/signature.py
@@ -26,7 +26,7 @@ class SignatureGrader(StandardGrader):
 
             submission_prefix = '#include "%s"\n' % handler_data['header']
             if not handler_data.get('allow_main', False):
-                submission_prefix += '#define main main_%s\n' % str(uuid.uuid4()).replace('-', '')
+                submission_prefix += '#define main main_%s\n' % uuid.uuid4().hex
 
             aux_sources[self.problem.id + '_submission'] = utf8bytes(submission_prefix) + self.source
 

--- a/dmoj/graders/signature.py
+++ b/dmoj/graders/signature.py
@@ -24,12 +24,9 @@ class SignatureGrader(StandardGrader):
             entry_point = self.problem.problem_data[handler_data['entry']]
             header = self.problem.problem_data[handler_data['header']]
 
-            # fmt: off
-            submission_prefix = (
-                '#include "%s"\n'
-                '#define main main_%s\n'
-            ) % (handler_data['header'], str(uuid.uuid4()).replace('-', ''))
-            # fmt: on
+            submission_prefix = '#include "%s"\n' % handler_data['header']
+            if not handler_data.get('allow_main', False):
+                submission_prefix += '#define main main_%s\n' % str(uuid.uuid4()).replace('-', '')
 
             aux_sources[self.problem.id + '_submission'] = utf8bytes(submission_prefix) + self.source
 


### PR DESCRIPTION
Some problems (e.g. CEOI '18 P6) use signature grading to emulate interaction, and so require the main to be left intact.

Fixes #730.