### PR TITLE
graders/standard: remove misleading PyPy branch

### DIFF
--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -1,6 +1,4 @@
-import gc
 import logging
-import platform
 import subprocess
 
 from dmoj.error import OutputLimitExceeded
@@ -38,16 +36,6 @@ class StandardGrader(BaseGrader):
         result.extended_feedback = check.extended_feedback or result.extended_feedback
 
         case.free_data()
-
-        # Where CPython has reference counting and a GC, PyPy only has a GC. This means that while CPython
-        # will have freed any (usually massive) generated data from the line above by reference counting, it might
-        # - and probably still is - in memory by now. We need to be able to fork() immediately, which has a good chance
-        # of failing if there's not a lot of swap space available.
-        #
-        # We don't really have a way to force the generated data to disappear, so calling a gc here is the best
-        # chance we have.
-        if platform.python_implementation() == 'PyPy':
-            gc.collect()
 
         return result
 


### PR DESCRIPTION
To begin with, we don't support PyPy at all.