### PR TITLE
judge: disallow running as root

### DIFF
--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -530,9 +530,11 @@ def sanity_check():
 
         # However running as root on Linux is a Bad Idea
         if os.getuid() == 0:
-            startup_warnings.append(
-                'running the judge as root can be potentially unsafe, consider using an unprivileged user instead'
+            print(
+                'running the judge as root is unsafe, please use an unprivileged user instead',
+                file=sys.stderr
             )
+            return False
 
         # Our sandbox filter is long but simple, so we can see large improvements
         # in overhead by enabling the BPF JIT for seccomp.


### PR DESCRIPTION
Letting this be an option is an invitation for people to use it without understanding the (major) repercussions, so let's just remove it.