### PR TITLE
Fix `problem_watches` watching nonsense directories; #723

### DIFF
--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -169,6 +169,9 @@ def load_env(cli=False, testsuite=False):  # pragma: no cover
             def get_path(x, y):
                 return utf8text(os.path.normpath(os.path.join(x, y)))
 
+            if isinstance(problem_dirs, str):
+                problem_dirs = [problem_dirs]
+
             problem_watches = []
             for dir in problem_dirs:
                 if isinstance(dir, ConfigNode):


### PR DESCRIPTION
Problem globs is on hold due to time constraints, and this fix should occur regardless (as we decided v2 of judge should still support `problem_storage_root`).