### PR TITLE
Test for absence of deprecation and other warnings on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ script:
     #!/bin/bash -e
     . ~/.profile
     cd /code
-    "$PYTHON" -Wdefault -m coverage run -m unittest discover dmoj/tests/
-    "$PYTHON" -Wdefault -m coverage run --append .docker.test.py
+    "$PYTHON" -W 'ignore::ResourceWarning,error' -m coverage run -m unittest discover dmoj/tests/
+    "$PYTHON" -W 'ignore::ResourceWarning,error' -m coverage run --append .docker.test.py
     "$PYTHON" -m coverage combine
     "$PYTHON" -m coverage xml
     EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ script:
     #!/bin/bash -e
     . ~/.profile
     cd /code
-    "$PYTHON" -Werror -m coverage run -m unittest discover dmoj/tests/
-    "$PYTHON" -Werror -m coverage run --append .docker.test.py
+    "$PYTHON" -Wdefault -m coverage run -m unittest discover dmoj/tests/
+    "$PYTHON" -Wdefauit -m coverage run --append .docker.test.py
     "$PYTHON" -m coverage combine
     "$PYTHON" -m coverage xml
     EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ script:
     #!/bin/bash -e
     . ~/.profile
     cd /code
-    "$PYTHON" -m coverage run -m unittest discover dmoj/tests/
-    "$PYTHON" -m coverage run --append .docker.test.py
+    "$PYTHON" -Werror -m coverage run -m unittest discover dmoj/tests/
+    "$PYTHON" -Werror -m coverage run --append .docker.test.py
     "$PYTHON" -m coverage combine
     "$PYTHON" -m coverage xml
     EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
     . ~/.profile
     cd /code
     "$PYTHON" -Wdefault -m coverage run -m unittest discover dmoj/tests/
-    "$PYTHON" -Wdefauit -m coverage run --append .docker.test.py
+    "$PYTHON" -Wdefault -m coverage run --append .docker.test.py
     "$PYTHON" -m coverage combine
     "$PYTHON" -m coverage xml
     EOF

--- a/dmoj/tests/test_control.py
+++ b/dmoj/tests/test_control.py
@@ -45,3 +45,4 @@ class ControlServerTest(unittest.TestCase):
     def tearDownClass(cls):
         cls.server.shutdown()
         cls.server_thread.join()
+        cls.server.server_close()

--- a/dmoj/tests/test_control.py
+++ b/dmoj/tests/test_control.py
@@ -20,9 +20,8 @@ class ControlServerTest(unittest.TestCase):
         cls.judge = Handler.judge
         cls.server = HTTPServer(('127.0.0.1', 0), Handler)
 
-        thread = threading.Thread(target=cls.server.serve_forever)
-        thread.daemon = True
-        thread.start()
+        cls.server_thread = threading.Thread(target=cls.server.serve_forever)
+        cls.server_thread.start()
 
         cls.connect = 'http://%s:%s/' % cls.server.server_address
 
@@ -45,3 +44,4 @@ class ControlServerTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.server.shutdown()
+        cls.server_thread.join()

--- a/dmoj/utils/module.py
+++ b/dmoj/utils/module.py
@@ -1,9 +1,9 @@
-import imp
 import os
+import types
 
 
 def load_module(name, code, filename=None):
-    mod = imp.new_module(name)
+    mod = types.ModuleType(name)
     if filename is not None:
         mod.__file__ = filename
     exec(compile(code, filename or '<string>', 'exec'), mod.__dict__)


### PR DESCRIPTION
This PR also fixes instances of deprecation and other warnings. This should prepare DMOJ for the release of Python 3.10, which will be removing old deprecated Python 2 names.