### PR TITLE
Disable codecov status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 coverage:
   status:
-    patch:
-      default: false
+    project: off
+    patch: off


### PR DESCRIPTION
This eliminates the spam of errors that we don't actually care about.