### PR TITLE
GO: use subdirectory for cache; fixes #770

### DIFF
--- a/dmoj/executors/GO.py
+++ b/dmoj/executors/GO.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 from dmoj.error import CompileError
@@ -40,7 +41,7 @@ func main() {
             # against arbitrary libraries.
             'CGO_ENABLED': '0',
             # We need GOCACHE to compile on Debian 10.0+.
-            'GOCACHE': self._dir,
+            'GOCACHE': os.path.join(self._dir, '.cache'),
         }
 
     def get_compile_args(self):


### PR DESCRIPTION
See example below:

```
root@4b0a20c790c2:/tmp/foo# CGO_ENABLED=0 GOCACHE=$(pwd) go build a1.go 
go build command-line-arguments: build output "a1" already exists and is a directory
root@4b0a20c790c2:/tmp/foo# ls
00  06	0c  12	18  1e	24  2a	30  36	3c  42	48  4e	54  5a	60  66	6c  72	78  7e	84  8a	90  96	9c	a1     a6  ac  b2  b8  be  c4  ca  d0  d6  dc  e2  e8  ee  f4  fa  trim.txt
01  07	0d  13	19  1f	25  2b	31  37	3d  43	49  4f	55  5b	61  67	6d  73	79  7f	85  8b	91  97	9d	a1.go  a7  ad  b3  b9  bf  c5  cb  d1  d7  dd  e3  e9  ef  f5  fb
02  08	0e  14	1a  20	26  2c	32  38	3e  44	4a  50	56  5c	62  68	6e  74	7a  80	86  8c	92  98	9e	a2     a8  ae  b4  ba  c0  c6  cc  d2  d8  de  e4  ea  f0  f6  fc
03  09	0f  15	1b  21	27  2d	33  39	3f  45	4b  51	57  5d	63  69	6f  75	7b  81	87  8d	93  99	9f	a3     a9  af  b5  bb  c1  c7  cd  d3  d9  df  e5  eb  f1  f7  fd
04  0a	10  16	1c  22	28  2e	34  3a	40  46	4c  52	58  5e	64  6a	70  76	7c  82	88  8e	94  9a	README	a4     aa  b0  b6  bc  c2  c8  ce  d4  da  e0  e6  ec  f2  f8  fe
05  0b	11  17	1d  23	29  2f	35  3b	41  47	4d  53	59  5f	65  6b	71  77	7d  83	89  8f	95  9b	a0	a5     ab  b1  b7  bd  c3  c9  cf  d5  db  e1  e7  ed  f3  f9  ff
root@4b0a20c790c2:/tmp/foo# cat README 
This directory holds cached build artifacts from the Go build system.
Run "go clean -cache" if the directory is getting too large.
See golang.org to learn more about Go.
```

Solution here is to create a subdirectory for the cache in the
submission directory, rather than use the directory itself.