### PR TITLE
executors: allow single-digit runtime version formatting for Java

### DIFF
--- a/dmoj/executors/gcc_executor.py
+++ b/dmoj/executors/gcc_executor.py
@@ -4,6 +4,7 @@ from collections import deque
 from typing import Dict, List
 
 from dmoj.executors.compiled_executor import CompiledExecutor
+from dmoj.executors.mixins import SingleDigitVersionMixin
 from dmoj.judgeenv import env
 from dmoj.utils.unicode import utf8bytes, utf8text
 
@@ -15,13 +16,12 @@ MAX_ERRORS = 5
 recppexc = re.compile(br"terminate called after throwing an instance of \'([A-Za-z0-9_:]+)\'\r?$", re.M)
 
 
-class GCCExecutor(CompiledExecutor):
+class GCCExecutor(SingleDigitVersionMixin, CompiledExecutor):
     defines: List[str] = []
     flags: List[str] = []
     name = 'GCC'
     arch = 'gcc_target_arch'
     has_color = False
-    version_regex = re.compile(r'.*?(\d+(?:\.\d+)*)', re.DOTALL)
 
     source_dict: Dict[str, bytes] = {}
 

--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from dmoj.error import CompileError, InternalError
 from dmoj.executors.compiled_executor import CompiledExecutor
+from dmoj.executors.mixins import SingleDigitVersionMixin
 from dmoj.judgeenv import skip_self_test
 from dmoj.utils.unicode import utf8bytes, utf8text
 
@@ -37,7 +38,7 @@ def find_class(source):
     return class_name
 
 
-class JavaExecutor(CompiledExecutor):
+class JavaExecutor(SingleDigitVersionMixin, CompiledExecutor):
     ext = 'java'
 
     vm: str

--- a/dmoj/executors/mixins.py
+++ b/dmoj/executors/mixins.py
@@ -153,3 +153,7 @@ class NullStdoutMixin:
         result = super().get_compile_popen_kwargs()
         result['stdout'] = self._devnull
         return result
+
+
+class SingleDigitVersionMixin:
+    version_regex = re.compile(r'.*?(\d+(?:\.\d+)*)', re.DOTALL)


### PR DESCRIPTION
```
root@53a4f2640160:/usr/lib/jvm# java-15-openjdk-amd64/bin/javac -version
javac 15
root@53a4f2640160:/usr/lib/jvm# java-1.8.0-openjdk-amd64/bin/javac -version
javac 1.8.0_265
```