### PR TITLE
executors: remove ScriptDirectoryMixin

### DIFF
--- a/dmoj/executors/DART.py
+++ b/dmoj/executors/DART.py
@@ -1,10 +1,9 @@
 from dmoj.executors.compiled_executor import CompiledExecutor
-from dmoj.executors.mixins import ScriptDirectoryMixin
 
 
 # Running DART normally results in unholy memory usage
 # Thankfully compiling it results in something...far more sane
-class Executor(ScriptDirectoryMixin, CompiledExecutor):
+class Executor(CompiledExecutor):
     ext = 'dart'
     name = 'DART'
     nproc = -1  # Dart uses a really, really large number of threads

--- a/dmoj/executors/FORTH.py
+++ b/dmoj/executors/FORTH.py
@@ -1,8 +1,7 @@
-from dmoj.executors.mixins import ScriptDirectoryMixin
 from dmoj.executors.script_executor import ScriptExecutor
 
 
-class Executor(ScriptDirectoryMixin, ScriptExecutor):
+class Executor(ScriptExecutor):
     name = 'FORTH'
     command = 'gforth'
     ext = 'fs'

--- a/dmoj/executors/RKT.py
+++ b/dmoj/executors/RKT.py
@@ -1,10 +1,9 @@
 import os
 
 from dmoj.executors.compiled_executor import CompiledExecutor
-from dmoj.executors.mixins import ScriptDirectoryMixin
 
 
-class Executor(ScriptDirectoryMixin, CompiledExecutor):
+class Executor(CompiledExecutor):
     ext = 'rkt'
     name = 'RKT'
     fs = [os.path.expanduser(r'~/\.racket/.*?'), '/etc/racket/.*?']

--- a/dmoj/executors/SBCL.py
+++ b/dmoj/executors/SBCL.py
@@ -1,5 +1,5 @@
 from dmoj.executors.compiled_executor import CompiledExecutor
-from dmoj.executors.mixins import NullStdoutMixin, ScriptDirectoryMixin
+from dmoj.executors.mixins import NullStdoutMixin
 
 
 # SBCL implements its own heap management, and relies on ASLR being disabled. So, on startup,
@@ -9,7 +9,7 @@ from dmoj.executors.mixins import NullStdoutMixin, ScriptDirectoryMixin
 # As of https://github.com/DMOJ/judge/issues/277 we set personality ourselves to disable ASLR,
 # so allowing (or blocking) the execve hack is not necessary: SBCL detects that ASLR is disabled,
 # and proceeds to run.
-class Executor(NullStdoutMixin, ScriptDirectoryMixin, CompiledExecutor):
+class Executor(NullStdoutMixin, CompiledExecutor):
     ext = 'cl'
     name = 'SBCL'
     command = 'sbcl'

--- a/dmoj/executors/mixins.py
+++ b/dmoj/executors/mixins.py
@@ -153,13 +153,3 @@ class NullStdoutMixin:
         result = super().get_compile_popen_kwargs()
         result['stdout'] = self._devnull
         return result
-
-
-class ScriptDirectoryMixin:
-    """
-    Certain script executors need access to the entire directory of the script,
-    usually for some searching purposes.
-    """
-
-    def get_fs(self):
-        return super().get_fs() + [self._dir]

--- a/dmoj/executors/python_executor.py
+++ b/dmoj/executors/python_executor.py
@@ -2,13 +2,12 @@ import re
 from collections import deque
 
 from dmoj.executors.compiled_executor import CompiledExecutor
-from dmoj.executors.mixins import ScriptDirectoryMixin
 from dmoj.utils.unicode import utf8bytes, utf8text
 
 retraceback = re.compile(r'Traceback \(most recent call last\):\n.*?\n([a-zA-Z_]\w*)(?::[^\n]*?)?$', re.S | re.M)
 
 
-class PythonExecutor(ScriptDirectoryMixin, CompiledExecutor):
+class PythonExecutor(CompiledExecutor):
     loader_script = '''\
 import runpy, sys, os
 del sys.argv[0]


### PR DESCRIPTION
Its functionality was absorbed by the standard executor base for a while
now.