### PR TITLE
Guard against large integers in checker and interactor handling

### DIFF
--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -8,7 +8,7 @@ import yaml
 from dmoj.config import ConfigNode
 
 # noinspection PyUnresolvedReferences
-from dmoj.utils import pyyaml_patch  # noqa: F401, imported for side effect
+from dmoj.utils import builtin_int_patch, pyyaml_patch  # noqa: F401, imported for side effect
 from dmoj.utils.unicode import utf8text
 
 problem_dirs = ()

--- a/dmoj/utils/builtin_int_patch.py
+++ b/dmoj/utils/builtin_int_patch.py
@@ -1,0 +1,21 @@
+# type: ignore
+
+INT_MAX_NUMBER_DIGITS = 10000
+
+
+class patched_int_meta(type):
+    def __subclasscheck__(cls, subclass):
+        return issubclass(subclass, bool) or super().__subclasscheck__(subclass)
+
+
+int_ = int
+
+
+class patched_int(int_, metaclass=patched_int_meta):
+    def __new__(self, s, *args, **kwargs):
+        if isinstance(s, str) and len(s) > INT_MAX_NUMBER_DIGITS:
+            raise ValueError('integer is too long')
+        return int_(s, *args, **kwargs)
+
+
+__builtins__.int, __builtins__.int_ = patched_int, int


### PR DESCRIPTION
```
  In [20]: int_ = __builtins__.int
  In [21]: def int(s):
      ...:     if isinstance(s, str):
      ...:         if len(s) > 1e5:
      ...:             raise ValueError("int too long")
      ...:     return int_(s)
      ...:
  In [22]: __builtins__.int = int_
  In [23]: __builtins__.int_ = int
  In [24]: int('1' * 10**7)
  ---------------------------------------------------------------------------
  ValueError                                Traceback (most recent call last)
  <ipython-input-24-a6262224c328> in <module>()
  ----> 1 int('1' * 10**7)
  <ipython-input-21-586e236f9dea> in int(s)
	2     if isinstance(s, str):
	3         if len(s) > 1e5:
  ----> 4             raise ValueError("int too long")
	5     return int_(s)
  ValueError: int too long
  In [25]: int_('1' * 10**7)
  ^C
```