### PR TITLE
Allow sys_poll globally to fix RUST failure

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -60,6 +60,7 @@ class IsolateTracer(dict):
                 sys_select: ALLOW,
                 sys_newselect: ALLOW,
                 sys_modify_ldt: ALLOW,
+                sys_poll: ALLOW,
                 sys_ppoll: ALLOW,
                 sys_getgroups32: ALLOW,
                 sys_sched_getaffinity: ALLOW,

--- a/dmoj/executors/COFFEE.py
+++ b/dmoj/executors/COFFEE.py
@@ -11,7 +11,6 @@ class Executor(ScriptExecutor):
     syscalls = [
         'newselect',
         'select',
-        'poll',
         'epoll_create1',
         'epoll_ctl',
         'epoll_wait',

--- a/dmoj/executors/HASK.py
+++ b/dmoj/executors/HASK.py
@@ -6,7 +6,6 @@ class Executor(NullStdoutMixin, CompiledExecutor):
     ext = 'hs'
     name = 'HASK'
     command = 'ghc'
-    syscalls = ['poll']
     test_program = '''\
 main = do
     a <- getContents

--- a/dmoj/executors/RKT.py
+++ b/dmoj/executors/RKT.py
@@ -10,7 +10,7 @@ class Executor(CompiledExecutor):
 
     command = 'racket'
 
-    syscalls = ['epoll_create', 'epoll_wait', 'poll']
+    syscalls = ['epoll_create', 'epoll_wait']
     # Racket SIGABRTs under low-memory conditions before actually crossing the memory limit,
     # so give it a bit of headroom to be properly marked as MLE.
     data_grace = 4096

--- a/dmoj/executors/RUBY2.py
+++ b/dmoj/executors/RUBY2.py
@@ -11,7 +11,7 @@ class Executor(ScriptExecutor):
     test_program = 'puts gets'
     nproc = -1
     command_paths = ['ruby2.%d' % i for i in reversed(range(0, 8))] + ['ruby2%d' % i for i in reversed(range(0, 8))]
-    syscalls = ['poll', 'thr_set_name', 'eventfd2']
+    syscalls = ['thr_set_name', 'eventfd2']
     fs = ['/proc/self/loginuid$']
 
     def get_fs(self):

--- a/dmoj/executors/SBCL.py
+++ b/dmoj/executors/SBCL.py
@@ -13,7 +13,7 @@ class Executor(NullStdoutMixin, CompiledExecutor):
     ext = 'cl'
     name = 'SBCL'
     command = 'sbcl'
-    syscalls = ['personality', 'poll']
+    syscalls = ['personality']
     test_program = '(write-line (read-line))'
     address_grace = 262144
     data_grace = 262144


### PR DESCRIPTION
There is little point restricting `sys_poll` when we allow `sys_select`.