### PR TITLE
Handle pre-/post-syscall errors

### DIFF
--- a/dmoj/cptbox/_cptbox.pyx
+++ b/dmoj/cptbox/_cptbox.pyx
@@ -414,10 +414,10 @@ cdef class Process:
             self._max_memory = get_memory(self.process.getpid()) or self._max_memory
         if event == PTBOX_EVENT_PROTECTION:
             with gil:
-                self._protection_fault(param, is_update=False)
+                self._protection_fault(<long>param, is_update=False)
         if event == PTBOX_EVENT_UPDATE_FAIL:
             with gil:
-                self._protection_fault(param, is_update=True)
+                self._protection_fault(<long>param, is_update=True)
         if event == PTBOX_EVENT_PTRACE_ERROR:
             with gil:
                 self._ptrace_error(param)

--- a/dmoj/cptbox/_cptbox.pyx
+++ b/dmoj/cptbox/_cptbox.pyx
@@ -76,6 +76,8 @@ cdef extern from 'ptbox.h' nogil:
     cdef int PTBOX_EVENT_EXITED
     cdef int PTBOX_EVENT_SIGNAL
     cdef int PTBOX_EVENT_PROTECTION
+    cdef int PTBOX_EVENT_PTRACE_ERROR
+    cdef int PTBOX_EVENT_UPDATE_FAIL
 
     cdef int PTBOX_EXIT_NORMAL
     cdef int PTBOX_EXIT_PROTECTION
@@ -412,7 +414,13 @@ cdef class Process:
             self._max_memory = get_memory(self.process.getpid()) or self._max_memory
         if event == PTBOX_EVENT_PROTECTION:
             with gil:
-                self._protection_fault(param)
+                self._protection_fault(param, is_update=False)
+        if event == PTBOX_EVENT_UPDATE_FAIL:
+            with gil:
+                self._protection_fault(param, is_update=True)
+        if event == PTBOX_EVENT_PTRACE_ERROR:
+            with gil:
+                self._ptrace_error(param)
         if event == PTBOX_EVENT_SIGNAL:
             if param != SIGTRAP:
                 self._signal = param
@@ -424,7 +432,10 @@ cdef class Process:
     cpdef _handler(self, abi, syscall, handler):
         self.process.set_handler(abi, syscall, handler)
 
-    cpdef _protection_fault(self, syscall):
+    cpdef _protection_fault(self, syscall, is_update):
+        pass
+
+    cpdef _ptrace_error(self, errno):
         pass
 
     cpdef _cpu_time_exceeded(self):

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -46,6 +46,8 @@
 #define PTBOX_EVENT_EXITED 2
 #define PTBOX_EVENT_SIGNAL 3
 #define PTBOX_EVENT_PROTECTION 4
+#define PTBOX_EVENT_PTRACE_ERROR 5
+#define PTBOX_EVENT_UPDATE_FAIL 6
 
 #define PTBOX_EXIT_NORMAL 0
 #define PTBOX_EXIT_PROTECTION 1
@@ -125,7 +127,7 @@ public:
     bool use_seccomp(bool enable);
 protected:
     int dispatch(int event, unsigned long param);
-    int protection_fault(int syscall);
+    int protection_fault(int syscall, int type = PTBOX_EVENT_PROTECTION);
 private:
     pid_t pid;
     int handler[PTBOX_ABI_COUNT][MAX_SYSCALL];
@@ -184,8 +186,8 @@ public:
     }
 #endif
 
-    void pre_syscall();
-    void post_syscall();
+    bool pre_syscall();
+    bool post_syscall();
     int abi() { return abi_; }
 
     static int native_abi;

--- a/dmoj/cptbox/ptdebug_arm.cpp
+++ b/dmoj/cptbox/ptdebug_arm.cpp
@@ -17,30 +17,33 @@ bool pt_debugger::supports_abi(int abi) {
 uint32_t pt_debugger::seccomp_non_native_arch_list[] = { 0 };
 #endif
 
-void pt_debugger::pre_syscall() {
+bool pt_debugger::pre_syscall() {
     struct iovec iovec;
     iovec.iov_base = &regs;
     iovec.iov_len = sizeof regs;
     if (ptrace(PTRACE_GETREGSET, tid, NT_PRSTATUS, &iovec)) {
         perror("ptrace(PTRACE_GETREGSET)");
         abi_ = PTBOX_ABI_INVALID;
+        return false;
     } else {
         abi_ = PTBOX_ABI_ARM;
         regs_changed = false;
+        return true;
     }
 }
 
-void pt_debugger::post_syscall() {
+bool pt_debugger::post_syscall() {
     if (!regs_changed || abi_ == PTBOX_ABI_INVALID)
-        return;
+        return true;
 
     struct iovec iovec;
     iovec.iov_base = &regs;
     iovec.iov_len = sizeof regs;
     if (ptrace(PTRACE_SETREGSET, tid, NT_PRSTATUS, &iovec)) {
         perror("ptrace(PTRACE_SETREGSET)");
-        abort();
+        return false;
     }
+    return true;
 }
 
 #define UNKNOWN_ABI(source) fprintf(stderr, source ": Invalid ABI\n"), abort()

--- a/dmoj/cptbox/ptdebug_arm64.cpp
+++ b/dmoj/cptbox/ptdebug_arm64.cpp
@@ -24,30 +24,33 @@ bool pt_debugger::supports_abi(int abi) {
 uint32_t pt_debugger::seccomp_non_native_arch_list[] = { SCMP_ARCH_ARM, 0 };
 #endif
 
-void pt_debugger::pre_syscall() {
+bool pt_debugger::pre_syscall() {
     struct iovec iovec;
     iovec.iov_base = &regs;
     iovec.iov_len = sizeof regs;
     if (ptrace(PTRACE_GETREGSET, tid, NT_PRSTATUS, &iovec)) {
         perror("ptrace(PTRACE_GETREGSET)");
         abi_ = PTBOX_ABI_INVALID;
+        return false;
     } else {
         abi_ = iovec.iov_len == sizeof regs.arm32 ? PTBOX_ABI_ARM : PTBOX_ABI_ARM64;
         regs_changed = false;
+        return true;
     }
 }
 
-void pt_debugger::post_syscall() {
+bool pt_debugger::post_syscall() {
     if (!regs_changed || abi_ == PTBOX_ABI_INVALID)
-        return;
+        return true;
 
     struct iovec iovec;
     iovec.iov_base = &regs;
     iovec.iov_len = abi_ == PTBOX_ABI_ARM ? sizeof regs.arm32 : sizeof regs.arm64;
     if (ptrace(PTRACE_SETREGSET, tid, NT_PRSTATUS, &iovec)) {
         perror("ptrace(PTRACE_SETREGSET)");
-        abort();
+        return false;
     }
+    return true;
 }
 
 #define UNKNOWN_ABI(source) fprintf(stderr, source ": Invalid ABI\n"), abort()

--- a/dmoj/cptbox/ptdebug_freebsd_x64.cpp
+++ b/dmoj/cptbox/ptdebug_freebsd_x64.cpp
@@ -13,24 +13,27 @@ bool pt_debugger::supports_abi(int abi) {
     return abi == PTBOX_ABI_FREEBSD_X64;
 }
 
-void pt_debugger::pre_syscall() {
+bool pt_debugger::pre_syscall() {
     if (ptrace(PT_GETREGS, tid, (caddr_t) &regs, 0)) {
         perror("ptrace(PT_GETREGS)");
         abi_ = PTBOX_ABI_INVALID;
+        return false;
     } else {
         abi_ = PTBOX_ABI_FREEBSD_X64;
         regs_changed = false;
+        return true;
     }
 }
 
-void pt_debugger::post_syscall() {
+bool pt_debugger::post_syscall() {
     if (!regs_changed || abi_ == PTBOX_ABI_INVALID)
-        return;
+        return true;
 
     if (ptrace(PT_SETREGS, tid, (caddr_t) &regs, 0)) {
         perror("ptrace(PTRACE_SETREGSET)");
-        abort();
+        return false;
     }
+    return true;
 }
 
 #define STRINGIFY(x) #x

--- a/dmoj/cptbox/ptdebug_x64.cpp
+++ b/dmoj/cptbox/ptdebug_x64.cpp
@@ -28,13 +28,14 @@ bool pt_debugger::supports_abi(int abi) {
 uint32_t pt_debugger::seccomp_non_native_arch_list[] = { SCMP_ARCH_X86, SCMP_ARCH_X32, 0 };
 #endif
 
-void pt_debugger::pre_syscall() {
+bool pt_debugger::pre_syscall() {
     struct iovec iovec;
     iovec.iov_base = &regs;
     iovec.iov_len = sizeof regs;
     if (ptrace(PTRACE_GETREGSET, tid, NT_PRSTATUS, &iovec)) {
         perror("ptrace(PTRACE_GETREGSET)");
         abi_ = PTBOX_ABI_INVALID;
+        return false;
     } else {
         if (iovec.iov_len == sizeof regs.x86) {
             abi_ = PTBOX_ABI_X86;
@@ -44,20 +45,22 @@ void pt_debugger::pre_syscall() {
             abi_ = PTBOX_ABI_X64;
         }
         regs_changed = false;
+        return true;
     }
 }
 
-void pt_debugger::post_syscall() {
+bool pt_debugger::post_syscall() {
     if (!regs_changed || abi_ == PTBOX_ABI_INVALID)
-        return;
+        return true;
 
     struct iovec iovec;
     iovec.iov_base = &regs;
     iovec.iov_len = abi_ == PTBOX_ABI_X86 ? sizeof regs.x86 : sizeof regs.x64;
     if (ptrace(PTRACE_SETREGSET, tid, NT_PRSTATUS, &iovec)) {
         perror("ptrace(PTRACE_SETREGSET)");
-        abort();
+        return false;
     }
+    return true;
 }
 
 #define UNKNOWN_ABI(source) fprintf(stderr, source ": Invalid ABI\n"), abort()

--- a/dmoj/cptbox/ptproc.cpp
+++ b/dmoj/cptbox/ptproc.cpp
@@ -199,6 +199,8 @@ int pt_process::monitor() {
 #endif
             if (!debugger->pre_syscall()) {
                 dispatch(PTBOX_EVENT_PTRACE_ERROR, errno);
+                exit_reason = protection_fault(-1);
+                continue;
             }
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1002501
             int syscall = lwpi.pl_syscall_code;

--- a/dmoj/cptbox/ptproc.cpp
+++ b/dmoj/cptbox/ptproc.cpp
@@ -78,8 +78,8 @@ int pt_process::spawn(pt_fork_handler child, void *context) {
     return 0;
 }
 
-int pt_process::protection_fault(int syscall) {
-    dispatch(PTBOX_EVENT_PROTECTION, syscall);
+int pt_process::protection_fault(int syscall, int type) {
+    dispatch(type, syscall);
     dispatch(PTBOX_EVENT_EXITING, PTBOX_EXIT_PROTECTION);
     killpg(pid, SIGKILL);
 #if PTBOX_FREEBSD
@@ -197,7 +197,9 @@ int pt_process::monitor() {
                 WSTOPSIG(status) == (0x80 | SIGTRAP)) {
             debugger->settid(pid);
 #endif
-            debugger->pre_syscall();
+            if (!debugger->pre_syscall()) {
+                dispatch(PTBOX_EVENT_PTRACE_ERROR, errno);
+            }
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1002501
             int syscall = lwpi.pl_syscall_code;
 #else
@@ -294,7 +296,11 @@ int pt_process::monitor() {
                 debugger->on_return_context = NULL;
             }
 
-            debugger->post_syscall();
+            if (!debugger->post_syscall()) {
+                dispatch(PTBOX_EVENT_PTRACE_ERROR, errno);
+                exit_reason = protection_fault(syscall, PTBOX_EVENT_UPDATE_FAIL);
+                continue;
+            }
         } else {
 #if PTBOX_FREEBSD
             // No events aside from signal event on FreeBSD

--- a/dmoj/cptbox/tracer.py
+++ b/dmoj/cptbox/tracer.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 from dmoj.cptbox._cptbox import *
 from dmoj.cptbox.handlers import ALLOW, DISALLOW, _CALLBACK
 from dmoj.cptbox.syscalls import SYSCALL_COUNT, by_id, translator, sys_exit, sys_exit_group, sys_getpid
-from dmoj.error import InternalError
 from dmoj.utils.communicate import safe_communicate as _safe_communicate
 from dmoj.utils.os_ext import (
     ARCH_A64,
@@ -284,12 +283,13 @@ class TracedPopen(Process):
         # When signed, 0xFFFFFFFF is equal to -1, meaning that ptrace failed to read the syscall for some reason.
         # We can't continue debugging as this could potentially be unsafe, so we should exit loudly.
         # See <https://github.com/DMOJ/judge/issues/181> for more details.
-        if syscall == 0xFFFFFFFF:
+        if syscall == -1:
             err = self._last_ptrace_errno
             if err is None:
-                raise InternalError('ptrace failed with unknown error')
+                log.error('ptrace failed with unknown error')
             else:
-                raise InternalError('ptrace error: %d (%s: %s)' % (err, errno.errorcode[err], os.strerror(err)))
+                log.error('ptrace error: %d (%s: %s)', err, errno.errorcode[err], os.strerror(err))
+            self.protection_fault = (-1, 'ptrace fail', [0] * 6, None)
         else:
             callname = self.debugger.get_syscall_name(syscall)
             self.protection_fault = (
@@ -307,7 +307,6 @@ class TracedPopen(Process):
             )
 
     def _ptrace_error(self, error):
-        log.warning('ptrace failed with error %d (%s): %s', error, errno.errorcode[error], os.strerror(error))
         self._last_ptrace_errno = error
 
     def _cpu_time_exceeded(self):

--- a/dmoj/result.py
+++ b/dmoj/result.py
@@ -89,7 +89,7 @@ class Result:
                 feedback = strsignal(process.signal).lower()
 
         if process.protection_fault:
-            syscall, callname, args = process.protection_fault
+            syscall, callname, args, update_errno = process.protection_fault
             print_protection_fault(process.protection_fault)
             callname = callname.replace('sys_', '', 1)
             message = '%s syscall disallowed' % callname

--- a/dmoj/utils/error.py
+++ b/dmoj/utils/error.py
@@ -1,10 +1,16 @@
+import errno
 import logging
+import os
 
 log = logging.getLogger('dmoj.cptbox')
 
 
 def print_protection_fault(fault):
-    syscall, callname, args = fault
-    log.warning('Protection fault on: %d (%s)', syscall, callname)
+    syscall, callname, args, update_errno = fault
+    if update_errno is not None:
+        log.warning('Failed to alter system call: %d (%s) with error %d (%s): %s',
+                    syscall, callname, update_errno, errno.errorcode[update_errno], os.strerror(update_errno))
+    else:
+        log.warning('Protection fault on: %d (%s)', syscall, callname)
     for i, arg in enumerate(args):
         log.warning('Arg%d: 0x%016x', i, arg)

--- a/dmoj/utils/helper_files.py
+++ b/dmoj/utils/helper_files.py
@@ -67,7 +67,7 @@ def parse_helper_file_error(proc, executor, name, stderr, time_limit, memory_lim
     elif proc.is_mle:
         error = '%s ran out of memory (> %s Kb)' % (name, memory_limit)
     elif proc.protection_fault:
-        syscall, callname, args = proc.protection_fault
+        syscall, callname, args, update_errno = proc.protection_fault
         error = '%s invoked disallowed syscall %s (%s)' % (name, syscall, callname)
     elif proc.returncode:
         if proc.returncode > 0:


### PR DESCRIPTION
Closes #797

* `pre_syscall` errno is now tracked and failure now results in a protection fault, e.g.
  ```
  WARNING 2020-12-29 00:17:50,494 error Protection fault on: -1 (ptrace fail)
  WARNING 2020-12-29 00:17:50,495 error Arg0: 0x0000000000000000
  WARNING 2020-12-29 00:17:50,495 error Arg1: 0x0000000000000000
  WARNING 2020-12-29 00:17:50,495 error Arg2: 0x0000000000000000
  WARNING 2020-12-29 00:17:50,495 error Arg3: 0x0000000000000000
  WARNING 2020-12-29 00:17:50,495 error Arg4: 0x0000000000000000
  WARNING 2020-12-29 00:17:50,495 error Arg5: 0x0000000000000000
  ```
* `post_syscall` failures are now converted into a special protection fault, e.g.
  ```
  WARNING 2020-12-28 00:56:47,105 error Failed to alter system call: 41 (sys_socket) with error 1 (EPERM): Operation not permitted
  WARNING 2020-12-28 00:56:47,105 error Arg0: 0x0000000000000001
  WARNING 2020-12-28 00:56:47,105 error Arg1: 0x0000000000080801
  WARNING 2020-12-28 00:56:47,105 error Arg2: 0x0000000000000000
  WARNING 2020-12-28 00:56:47,105 error Arg3: 0x0000000000000006
  WARNING 2020-12-28 00:56:47,105 error Arg4: 0x0000000000000001
  WARNING 2020-12-28 00:56:47,105 error Arg5: 0x0000000000000000
  ```