### PR TITLE
Fix logic related to process initialization detection

### DIFF
--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -164,7 +164,7 @@ public:
     void arg4(long);
     void arg5(long);
 
-    int first_execve_syscall_id();
+    bool is_end_of_first_execve();
 
     void set_process(pt_process *);
     void new_process();

--- a/dmoj/cptbox/ptdebug_arm.cpp
+++ b/dmoj/cptbox/ptdebug_arm.cpp
@@ -81,11 +81,14 @@ MAKE_ACCESSOR(arg5, ARM_r5)
 
 #undef MAKE_ACCESSOR
 
-int pt_debugger::first_execve_syscall_id() {
-    // There is no orig_r8 on ARM, and execve clears all registers.
-    // Therefore, 0 is the register value when coming out of a system call.
-    // We will pretend 0 is execve.
-    return process->use_seccomp() ? 11 : 0;
+bool pt_debugger::is_end_of_first_execve() {
+    if (process->use_seccomp()) {
+        return syscall() == 11;
+    } else {
+        // There is no orig_x8 on ARM, and execve clears all registers when finished.
+        // Therefore, 0 is the register value when coming out of a system call.
+        return !is_enter() && syscall() == 0 && result() == 0;
+    }
 }
 
 #endif /* __arm__ */

--- a/dmoj/cptbox/ptdebug_freebsd_x64.cpp
+++ b/dmoj/cptbox/ptdebug_freebsd_x64.cpp
@@ -71,7 +71,7 @@ MAKE_ACCESSOR(arg5, r9)
 
 #undef MAKE_ACCESSOR
 
-int pt_debugger::first_execve_syscall_id() {
-    return 59;
+bool pt_debugger::is_end_of_first_execve() {
+    return !is_enter() && syscall() == 59 && result() == 0;
 }
 #endif /* __amd64__ */

--- a/dmoj/cptbox/ptdebug_x64.cpp
+++ b/dmoj/cptbox/ptdebug_x64.cpp
@@ -117,6 +117,7 @@ MAKE_ACCESSOR(arg5, ebp, r9)
 #undef MAKE_ACCESSOR
 
 int pt_debugger::first_execve_syscall_id() {
-    return 59;
+    // When not using seccomp, upon exit from execve to a 32-bit process, orig_eax turns to sys_execve on 32-bit.
+    return process->use_seccomp() || abi_ != PTBOX_ABI_X86 ? 59 : 11;
 }
 #endif /* __amd64__ */

--- a/dmoj/cptbox/ptdebug_x86.cpp
+++ b/dmoj/cptbox/ptdebug_x86.cpp
@@ -89,7 +89,11 @@ long pt_debugger::arg5() {
 
 void pt_debugger::arg5(long data) {}
 
-int pt_debugger::first_execve_syscall_id() {
-    return 11;
+bool pt_debugger::is_end_of_first_execve() {
+    if (process->use_seccomp()) {
+        return syscall() == 11;
+    } else {
+        return !is_enter() && syscall() == 11 && result() == 0;
+    }
 }
 #endif /* __i386__ */

--- a/dmoj/cptbox/tracer.py
+++ b/dmoj/cptbox/tracer.py
@@ -197,6 +197,8 @@ class TracedPopen(Process):
                 )
             elif self.returncode == PTBOX_SPAWN_FAIL_EXECVE:
                 raise RuntimeError('failed to spawn child')
+            elif self.returncode >= 0:
+                raise RuntimeError('process failed to initialize with unknown exit code: %d' % self.returncode)
         return self.returncode
 
     def poll(self):


### PR DESCRIPTION
Correctly ensure that process initialization is correctly detected (i.e. `pt_proc::_initialized` is correctly set). Also add an exception to be thrown if the process exited successfully without setting the initialization flag, allowing such bugs in the future to be detected.