### PR TITLE
Implement memfd-backed MemoryIO class

### DIFF
--- a/dmoj/cptbox/_cptbox.pyi
+++ b/dmoj/cptbox/_cptbox.pyi
@@ -18,3 +18,6 @@ Process: Any
 AT_FDCWD: int
 bsd_get_proc_cwd: Callable[[int], str]
 bsd_get_proc_fdno: Callable[[int, int], str]
+
+memory_fd_create: Callable[[], int]
+memory_fd_seal: Callable[[int], None]

--- a/dmoj/cptbox/_cptbox.pyx
+++ b/dmoj/cptbox/_cptbox.pyx
@@ -131,6 +131,9 @@ cdef extern from 'helper.h' nogil:
         PTBOX_SPAWN_FAIL_TRACEME
         PTBOX_SPAWN_FAIL_EXECVE
 
+    int _memory_fd_create "memory_fd_create"()
+    int _memory_fd_seal "memory_fd_seal"(int fd)
+
 
 cdef extern from 'fcntl.h' nogil:
     cpdef enum:
@@ -206,6 +209,16 @@ def bsd_get_proc_fdno(pid_t pid, int fd):
     free(buf)
     return res
 
+def memory_fd_create():
+    cdef int fd = _memory_fd_create()
+    if fd < 0:
+        PyErr_SetFromErrno(OSError)
+    return fd
+
+def memory_fd_seal(int fd):
+    cdef int result = _memory_fd_seal(fd)
+    if result == -1:
+        PyErr_SetFromErrno(OSError)
 
 cdef class Process
 

--- a/dmoj/cptbox/helper.h
+++ b/dmoj/cptbox/helper.h
@@ -31,4 +31,7 @@ int cptbox_child_run(const struct child_config *config);
 char *bsd_get_proc_cwd(pid_t pid);
 char *bsd_get_proc_fdno(pid_t pid, int fdno);
 
+int memory_fd_create(void);
+int memory_fd_seal(int fd);
+
 #endif

--- a/dmoj/cptbox/utils.py
+++ b/dmoj/cptbox/utils.py
@@ -1,0 +1,11 @@
+import io
+
+from dmoj.cptbox._cptbox import memory_fd_create, memory_fd_seal
+
+
+class MemoryIO(io.FileIO):
+    def __init__(self) -> None:
+        super().__init__(memory_fd_create(), 'r+')
+
+    def seal(self) -> None:
+        memory_fd_seal(self.fileno())

--- a/dmoj/tests/test_memory_io.py
+++ b/dmoj/tests/test_memory_io.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import unittest
+
+from dmoj.cptbox.utils import MemoryIO
+
+TEST_DATA = b'Hello, World!'
+
+
+class TestMemoryIO(unittest.TestCase):
+    def test_read_back(self):
+        with MemoryIO() as f:
+            f.write(TEST_DATA)
+            f.seek(0, os.SEEK_SET)
+            self.assertEqual(f.read(), TEST_DATA)
+
+    @unittest.skipIf(sys.platform.startswith('freebsd'), 'Sealing not supported on FreeBSD')
+    def test_seal(self):
+        with MemoryIO() as f:
+            f.write(TEST_DATA)
+            f.seal()
+
+            f.seek(0, os.SEEK_SET)
+            self.assertEqual(f.read(), TEST_DATA)
+
+            with self.assertRaises(IOError):
+                f.write(TEST_DATA)
+
+            with self.assertRaises(IOError):
+                f.truncate(0)


### PR DESCRIPTION
This class can be used to create virtual files backed by memory and
later pass them as input to other processes, e.g. user submissions.
These virtual files can be sealed to prevent modification after
passing them to other processes.

On FreeBSD, we use shm_open(SHM_ANON) as a fallback option, which
should do similar things. Note that sealing is not supported on
FreeBSD.

Unit tests were also added.