### PR TITLE
Fix cptbox build issues on FreeBSD

### DIFF
--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -178,6 +178,7 @@ public:
 #if PTBOX_FREEBSD
     void update_syscall(struct ptrace_lwpinfo *info);
     void setpid(pid_t pid);
+    bool is_enter() { return _bsd_in_syscall; }
 #else
     void settid(pid_t tid);
     void tid_reset(pid_t tid);
@@ -215,6 +216,7 @@ private:
     char *readstr_peekdata(unsigned long addr, size_t max_size);
 #if PTBOX_FREEBSD
     int _bsd_syscall;
+    bool _bsd_in_syscall;
 #else
     std::map<pid_t, int> syscall_;
 #endif

--- a/dmoj/cptbox/ptproc.cpp
+++ b/dmoj/cptbox/ptproc.cpp
@@ -224,6 +224,7 @@ int pt_process::monitor() {
 #endif
 #if PTBOX_FREEBSD
             in_syscall = lwpi.pl_flags & PL_FLAG_SCE;
+            debugger->_bsd_in_syscall = in_syscall;
 #else
             in_syscall = debugger->is_enter();
 #endif


### PR DESCRIPTION
Basically implement `pt_debugger::is_syscall()` on FreeBSD.