### PR TITLE
Allow for checkers to call `int()`

### DIFF
--- a/dmoj/tests/test_int_patch.py
+++ b/dmoj/tests/test_int_patch.py
@@ -39,6 +39,7 @@ class IntrospectionTest(unittest.TestCase):
         self.assertEqual(type(1), int)
 
     def test_identity(self):
+        self.assertIs(int(), 0)
         self.assertIs(int(1), 1)
         self.assertIs(type(int(1)), int_)
 

--- a/dmoj/utils/builtin_int_patch.py
+++ b/dmoj/utils/builtin_int_patch.py
@@ -24,7 +24,7 @@ class patched_int_meta(type):
 
 
 class patched_int(int_, metaclass=patched_int_meta):
-    def __new__(cls, s, *args, **kwargs):
+    def __new__(cls, s=0, *args, **kwargs):
         if isinstance(s, str) and len(s) > INT_MAX_NUMBER_DIGITS:
             raise ValueError('integer is too long')
         if cls is patched_int:


### PR DESCRIPTION
The current behaviour requires an argument to be passed to `int(...)`, however, this breaks `defaultdict(int)`.