### PR TITLE
Set update-syscalls PR author to dmoj-build

### DIFF
--- a/.github/workflows/update-syscalls.yml
+++ b/.github/workflows/update-syscalls.yml
@@ -20,6 +20,8 @@ jobs:
       uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.REPO_SCOPED_TOKEN }}
+        author: dmoj-build <build@dmoj.ca>
+        committer: dmoj-build <build@dmoj.ca>
         commit-message: 'cptbox: update Linux syscall list'
         title: 'Update Linux syscall list'
         body: This PR has been auto-generated to update the syscall definitions in `cptbox`.


### PR DESCRIPTION
The current behaviour is using whoever committed last on master as the author.
This is clearly a misattribution.