### PR TITLE
Add python 3.9 classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Education',
         'Topic :: Software Development',
     ],


### PR DESCRIPTION
We released 3.0.x after adding 3.9 support and forgot to tag it properly.