### PR TITLE
Add executor for Pyston

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The judge can also grade in the languages listed below. These languages are less
 * V8 JavaScript
 * Brain\*\*\*\*
 * Zig
+* Pyston
 
 ## Installation
 Installing the DMOJ judge creates two executables in your Python's script directory: `dmoj` and `dmoj-cli`.

--- a/dmoj/executors/PYSTON.py
+++ b/dmoj/executors/PYSTON.py
@@ -1,0 +1,22 @@
+from typing import List, Tuple
+
+from dmoj.executors.python_executor import PythonExecutor
+
+
+class Executor(PythonExecutor):
+    name = 'PYSTON'
+    command = 'pyston'
+    test_program = "print(__import__('sys').stdin.read(), end='')"
+    _pyston_versions: List[Tuple[int, ...]]
+
+    @classmethod
+    def parse_version(cls, command, output):
+        try:
+            cls._pyston_versions = [tuple(map(int, version.split('.'))) for version in cls.version_regex.findall(output)]
+            return cls._pyston_versions[2]
+        except Exception:
+            return None
+
+    @classmethod
+    def get_runtime_versions(cls):
+        return tuple(list(super().get_runtime_versions()) + [('implementing python', cls._pyston_versions[0])])


### PR DESCRIPTION
Added executor for [Pyston](https://github.com/pyston/pyston) interpreter. I tested it with `dmoj-cli`

![image](https://user-images.githubusercontent.com/36890802/117457953-c211ff00-af17-11eb-922e-19d1eca806bc.png)
