### PR TITLE
docker: set $HOME before sourcing profile

### DIFF
--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -4,7 +4,7 @@ ARG TAG=master
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/DMOJ/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	pip3 install -e . && \
-	. ~judge/.profile && \
+	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
 	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml
 

--- a/.docker/tier2/Dockerfile
+++ b/.docker/tier2/Dockerfile
@@ -4,8 +4,7 @@ ARG TAG=master
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/DMOJ/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	pip3 install -e . && \
-	sed -i 's/source "$HOME/. "\/home\/judge/' ~judge/.profile && \
-	. ~judge/.profile && \
+	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
 	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml
 

--- a/.docker/tier3/Dockerfile
+++ b/.docker/tier3/Dockerfile
@@ -4,8 +4,7 @@ ARG TAG=master
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/DMOJ/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	pip3 install -e . && \
-	sed -i 's/source "$HOME/. "\/home\/judge/' ~judge/.profile && \
-	. ~judge/.profile && \
+	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
 	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml
 


### PR DESCRIPTION
This fixes $HOME pointing to /root, fixing the following error during
autoconf:

    /bin/sh: 31: .: cannot open /root/.cargo/env: No such file

An alternative here would be to use the USER Docker directive, but that
required making /judge-runtime-paths.yml writable by the judge user.
This is simpler.