### PR TITLE
Create a configuration file for the judge inside the container.

### DIFF
--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -6,6 +6,8 @@ RUN mkdir /judge /problems && cd /judge && \
 	pip3 install -e . && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
-	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml
+	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
+	echo 'problem_storage_root: [ "/problems" ]' > /judge.yml && \
+	cat /judge-runtime-paths.yml >> /judge.yml
 
 ENTRYPOINT ["/judge/.docker/entry"]

--- a/.docker/tier2/Dockerfile
+++ b/.docker/tier2/Dockerfile
@@ -6,6 +6,8 @@ RUN mkdir /judge /problems && cd /judge && \
 	pip3 install -e . && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
-	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml
+	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
+	echo 'problem_storage_root: [ "/problems" ]' > /judge.yml && \
+	cat /judge-runtime-paths.yml >> /judge.yml
 
 ENTRYPOINT ["/judge/.docker/entry"]

--- a/.docker/tier3/Dockerfile
+++ b/.docker/tier3/Dockerfile
@@ -6,6 +6,8 @@ RUN mkdir /judge /problems && cd /judge && \
 	pip3 install -e . && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
-	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml
+	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
+	echo 'problem_storage_root: [ "/problems" ]' > /judge.yml && \
+	cat /judge-runtime-paths.yml >> /judge.yml
 
 ENTRYPOINT ["/judge/.docker/entry"]


### PR DESCRIPTION
Then we can use this command to run the judge

```shell
docker run \
  --name judge \
  -v /mnt/dmoj/problems:/problems \
  --cap-add=SYS_PTRACE \
  -d \
  dmoj/judge-tier3:latest \
  run -c /judge.yml $BRIDGE_ADDRESS $JUDGE_NAME $JUDGE_KEY
```

Some benefits of this command are:

- No need to extract the contents of the file `/judge-runtime-paths.yml` outside the container for the configuration of the judge.
- It is easier to run multiple judges using different values for the variables JUDGE_NAME and JUDGE_KEY.