### PR TITLE
change regex to filesystem policy matcher, first step of #871

### DIFF
--- a/.freebsd.test.py
+++ b/.freebsd.test.py
@@ -31,13 +31,18 @@ OVERRIDES = {}
 
 def main():
     judgeenv.env['runtime'] = {}
-    judgeenv.env['extra_fs'] = {'PERL': ['/dev/dtrace/helper$'], 'RUBY2': ['/dev/dtrace/helper$']}
+    judgeenv.env['extra_fs'] = {
+        'PERL': [{'exact_file': '/dev/dtrace/helper'}],
+        'RUBY2': [{'exact_file': '/dev/dtrace/helper'}],
+    }
 
     logging.basicConfig(level=logging.INFO)
 
     print('Using extra allowed filesystems:')
     for lang, fs in judgeenv.env['extra_fs'].iteritems():
-        print('%-6s: %s' % (lang, '|'.join(fs)))
+        for rules in fs:
+            for access_type, file in rules.iteritems():
+                print('%-6s: %s: %s' % (lang, access_type, file))
     print()
 
     print('Testing executors...')

--- a/dmoj/cptbox/filesystem_policies.py
+++ b/dmoj/cptbox/filesystem_policies.py
@@ -1,0 +1,117 @@
+import os
+from enum import Enum
+from typing import List, Union
+
+
+class AccessMode(Enum):
+    NONE = 0
+    EXACT = 1
+    RECURSIVE = 2
+
+    # flake8 doesn't recognize `AccessMode` in type annotations here
+    @classmethod
+    def more_permissive(cls, mode1, mode2):
+        return cls(max(mode1.value, mode2.value))
+
+
+class Dir:
+    def __init__(self):
+        self.access_mode = AccessMode.NONE
+        self.subpath_map = {}
+
+
+class File:
+    pass
+
+
+class ExactFile:
+    def __init__(self, path: str):
+        self.path = path
+
+
+class ExactDir:
+    access_mode = AccessMode.EXACT
+
+    def __init__(self, path: str):
+        self.path = path
+
+
+class RecursiveDir:
+    access_mode = AccessMode.RECURSIVE
+
+    def __init__(self, path: str):
+        self.path = path
+
+
+FilesystemAccessRule = Union[ExactFile, ExactDir, RecursiveDir]
+
+
+class FilesystemPolicy:
+    def __init__(self, rules: List[FilesystemAccessRule]):
+        self.root = Dir()
+        for rule in rules:
+            self._add_rule(rule)
+
+    def _add_rule(self, rule: FilesystemAccessRule) -> None:
+        self._assert_rule_type(rule)
+        if rule.path == '/':
+            return self._finalize_root_rule(rule)
+
+        path = rule.path
+        assert os.path.abspath(path) == path, 'FilesystemAccessRule must specify a normalized, absolute path to rule'
+        *directory_path, final_component = path.split('/')[1:]
+
+        node = self.root
+        for component in directory_path:
+            new_node = node.subpath_map.setdefault(component, Dir())
+            assert isinstance(new_node, Dir), 'Cannot add rule: refusing to descend into non-directory'
+            node = new_node
+
+        self._finalize_rule(node, final_component, rule)
+
+    def _assert_rule_type(self, rule: FilesystemAccessRule) -> None:
+        if os.path.exists(rule.path):
+            is_dir = os.path.isdir(rule.path)
+            if isinstance(rule, ExactFile):
+                assert not is_dir, f"Can't apply file rule to directory {rule.path}"
+            else:
+                assert is_dir, f"Can't apply directory rule to non-directory {rule.path}"
+
+    def _finalize_root_rule(self, rule: FilesystemAccessRule) -> None:
+        assert not isinstance(rule, ExactFile), 'Root is not a file'
+        self._finalize_directory_rule(self.root, rule)
+
+    def _finalize_rule(self, node: Dir, final_component: str, rule: FilesystemAccessRule) -> None:
+        assert final_component != '', 'Must not have trailing slashes in rule path'
+        if isinstance(rule, ExactFile):
+            new_node = node.subpath_map.setdefault(final_component, File())
+            assert isinstance(new_node, File), "Can't add ExactFile: Dir rule exists"
+        else:
+            new_node = node.subpath_map.setdefault(final_component, Dir())
+            assert isinstance(new_node, Dir), "Can't add rule: File rule exists"
+            self._finalize_directory_rule(new_node, rule)
+
+    def _finalize_directory_rule(self, node: Dir, rule: Union[ExactDir, RecursiveDir]) -> None:
+        node.access_mode = AccessMode.more_permissive(
+            node.access_mode, rule.access_mode
+        )  # Allow the more permissive rule
+
+    # `path` should be a normalized path
+    def check(self, path: str) -> bool:
+        assert os.path.abspath(path) == path, 'Must pass a normalized, absolute path to check'
+
+        node = self.root
+        for component in path.split('/')[1:]:
+            if isinstance(node, File):
+                return False
+            elif node.access_mode == AccessMode.RECURSIVE:
+                return True
+            else:
+                node = node.subpath_map.get(component)
+                if node is None:
+                    return False
+
+        return self._check_final_node(node)
+
+    def _check_final_node(self, node: Union[Dir, File]) -> bool:
+        return isinstance(node, File) or node.access_mode != AccessMode.NONE

--- a/dmoj/executors/COFFEE.py
+++ b/dmoj/executors/COFFEE.py
@@ -1,5 +1,6 @@
 import os
 
+from dmoj.cptbox.filesystem_policies import ExactFile
 from dmoj.executors.script_executor import ScriptExecutor
 
 
@@ -38,7 +39,7 @@ process.stdin.on 'readable', () ->
         return [self.get_command(), self.runtime_dict['coffee'], self._code]
 
     def get_fs(self):
-        return super().get_fs() + [self.runtime_dict['coffee'], self._code]
+        return super().get_fs() + [ExactFile(self.runtime_dict['coffee']), ExactFile(self._code)]
 
     @classmethod
     def get_versionable_commands(cls):

--- a/dmoj/executors/DART.py
+++ b/dmoj/executors/DART.py
@@ -16,7 +16,6 @@ void main() {
     address_grace = 128 * 1024
 
     syscalls = ['epoll_create', 'epoll_ctl', 'epoll_wait', 'timerfd_settime', 'memfd_create', 'ftruncate']
-    fs = ['.*/vm-service$']
 
     def get_compile_args(self):
         return [self.get_command(), '--snapshot=%s' % self.get_compiled_file(), self._code]

--- a/dmoj/executors/FORTH.py
+++ b/dmoj/executors/FORTH.py
@@ -1,3 +1,4 @@
+from dmoj.cptbox.filesystem_policies import ExactFile
 from dmoj.executors.script_executor import ScriptExecutor
 
 
@@ -10,7 +11,7 @@ class Executor(ScriptExecutor):
 
 HELLO
 """
-    fs = [r'/\.gforth-history$']
+    fs = [ExactFile('/.gforth-history')]
 
     def get_cmdline(self, **kwargs):
         return [self.get_command(), self._code, '-e', 'bye']

--- a/dmoj/executors/PERL.py
+++ b/dmoj/executors/PERL.py
@@ -1,3 +1,4 @@
+from dmoj.cptbox.filesystem_policies import RecursiveDir
 from dmoj.executors.script_executor import ScriptExecutor
 
 
@@ -5,7 +6,7 @@ class Executor(ScriptExecutor):
     ext = 'pl'
     name = 'PERL'
     command = 'perl'
-    fs = ['/etc/perl/.*?']
+    fs = [RecursiveDir('/etc/perl')]
     test_program = 'print<>'
     syscalls = ['umtx_op']
 

--- a/dmoj/executors/PHP.py
+++ b/dmoj/executors/PHP.py
@@ -7,8 +7,6 @@ class Executor(ScriptExecutor):
     command = 'php'
     command_paths = ['php7', 'php5', 'php']
 
-    fs = [r'.*/php[\w-]*\.ini$', r'.*/conf.d/.*\.ini$']
-
     test_program = '<?php while($f = fgets(STDIN)) echo $f;'
 
     def get_cmdline(self, **kwargs):

--- a/dmoj/executors/RKT.py
+++ b/dmoj/executors/RKT.py
@@ -1,17 +1,11 @@
-import os
-
+from dmoj.cptbox.filesystem_policies import ExactFile, RecursiveDir
 from dmoj.executors.compiled_executor import CompiledExecutor
 
 
 class Executor(CompiledExecutor):
     ext = 'rkt'
     name = 'RKT'
-    fs = [
-        os.path.expanduser(r'~/\.racket/'),
-        os.path.expanduser(r'~/\.local/share/racket/'),
-        '/etc/racket/.*?',
-        '/etc/passwd$',
-    ]
+    fs = [RecursiveDir('/etc/racket'), ExactFile('/etc/passwd')]
 
     command = 'racket'
 

--- a/dmoj/executors/RUBY2.py
+++ b/dmoj/executors/RUBY2.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+from dmoj.cptbox.filesystem_policies import ExactFile
 from dmoj.executors.script_executor import ScriptExecutor
 
 
@@ -12,7 +13,7 @@ class Executor(ScriptExecutor):
     nproc = -1
     command_paths = ['ruby2.%d' % i for i in reversed(range(0, 8))] + ['ruby2%d' % i for i in reversed(range(0, 8))]
     syscalls = ['thr_set_name', 'eventfd2']
-    fs = ['/proc/self/loginuid$']
+    fs = [ExactFile('/proc/self/loginuid')]
 
     def get_fs(self):
         fs = super().get_fs()

--- a/dmoj/executors/SWIFT.py
+++ b/dmoj/executors/SWIFT.py
@@ -5,7 +5,6 @@ class Executor(CompiledExecutor):
     ext = 'swift'
     name = 'SWIFT'
     command = 'swiftc'
-    fs = ['/lib']
     test_program = 'print(readLine()!)'
 
     def get_compile_args(self):

--- a/dmoj/executors/TUR.py
+++ b/dmoj/executors/TUR.py
@@ -1,5 +1,6 @@
 import os
 
+from dmoj.cptbox.filesystem_policies import ExactFile
 from dmoj.executors.compiled_executor import CompiledExecutor
 from dmoj.judgeenv import env
 
@@ -15,7 +16,7 @@ put echo
 """
 
     def get_fs(self):
-        return super().get_fs() + [self._code + 'bc']
+        return super().get_fs() + [ExactFile(self._code + 'bc')]
 
     def get_compile_args(self):
         tprologc = self.runtime_dict['tprologc']

--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -7,6 +7,7 @@ from collections import deque
 from pathlib import PurePath
 from typing import Optional
 
+from dmoj.cptbox.filesystem_policies import ExactDir, ExactFile
 from dmoj.error import CompileError, InternalError
 from dmoj.executors.compiled_executor import CompiledExecutor
 from dmoj.executors.mixins import SingleDigitVersionMixin
@@ -87,12 +88,12 @@ class JavaExecutor(SingleDigitVersionMixin, CompiledExecutor):
     def get_fs(self):
         return (
             super().get_fs()
-            + [f'{re.escape(self._agent_file)}$']
-            + [f'{re.escape(str(parent))}$' for parent in PurePath(self._agent_file).parents]
+            + [ExactFile(self._agent_file)]
+            + [ExactDir(str(parent)) for parent in PurePath(self._agent_file).parents]
         )
 
     def get_write_fs(self):
-        return super().get_write_fs() + [os.path.join(self._dir, 'submission_jvm_crash.log')]
+        return super().get_write_fs() + [ExactFile(os.path.join(self._dir, 'submission_jvm_crash.log'))]
 
     def get_agent_flag(self):
         agent_flag = '-javaagent:%s=policy:%s' % (self._agent_file, self._policy_file)

--- a/dmoj/executors/mono_executor.py
+++ b/dmoj/executors/mono_executor.py
@@ -3,6 +3,7 @@ import re
 from collections import deque
 
 from dmoj.cptbox import TracedPopen
+from dmoj.cptbox.filesystem_policies import RecursiveDir
 from dmoj.cptbox.handlers import ACCESS_EAGAIN
 from dmoj.executors.compiled_executor import CompiledExecutor
 from dmoj.result import Result
@@ -32,7 +33,7 @@ class MonoExecutor(CompiledExecutor):
     # get flagged as MLE.
     data_grace = 65536
     cptbox_popen_class = MonoTracedPopen
-    fs = ['/etc/mono/']
+    fs = [RecursiveDir('/etc/mono')]
     # Mono sometimes forks during its crashdump procedure, but continues even if
     # the call to fork fails.
     syscalls = [

--- a/dmoj/executors/script_executor.py
+++ b/dmoj/executors/script_executor.py
@@ -1,7 +1,7 @@
 import os
-import re
 from typing import List, Optional
 
+from dmoj.cptbox.filesystem_policies import ExactFile, RecursiveDir
 from dmoj.executors.base_executor import BaseExecutor
 from dmoj.utils.unicode import utf8bytes
 
@@ -24,9 +24,9 @@ class ScriptExecutor(BaseExecutor):
 
     def get_fs(self) -> list:
         home = self.runtime_dict.get('%s_home' % self.get_executor_name().lower())
-        fs = super().get_fs() + [self._code]
+        fs = super().get_fs() + [ExactFile(self._code)]
         if home is not None:
-            fs.append(re.escape(home))
+            fs += [RecursiveDir(home)]
         return fs
 
     def create_files(self, problem_id: str, source_code: bytes) -> None:

--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -25,9 +25,20 @@ env = ConfigNode(
         'compiled_binary_cache_dir': None,  # Location to store cached binaries, defaults to tempdir
         'compiled_binary_cache_size': 100,  # Maximum number of executables to cache (LRU order)
         'runtime': {},
-        # Map of executor: [list of extra allowed file regexes], used to configure
+        # Map of executor: fs_config, used to configure
         # the filesystem sandbox on a per-machine basis, without having to hack
         # executor source.
+        # fs_config is a list of dictionaries. Each dictionary should contain one key/value pair.
+        # Three keys are possible:
+        # `exact_file`, to allow a specific file
+        # `exact_dir`, to allow listing files in a directory
+        # `recursive_dir`, to allow everything under and including a directory
+        # Example YAML:
+        # extra_fs:
+        #   PERL:
+        #   - exact_file: /dev/dtrace/helper
+        #   - exact_dir: /some/exact/directory
+        #   - recursive_dir: /some/directory/and/all/children
         'extra_fs': {},
         # List of judge URLs to ping on problem data updates (the URLs are expected
         # to host judges running with --api-host and --api-port)

--- a/dmoj/tests/test_filesystem_policy.py
+++ b/dmoj/tests/test_filesystem_policy.py
@@ -1,0 +1,62 @@
+import unittest
+
+from dmoj.cptbox.filesystem_policies import ExactDir, ExactFile, FilesystemPolicy, RecursiveDir
+
+
+class CheckerTest(unittest.TestCase):
+    def test_exact_dir(self):
+        self.fs = FilesystemPolicy([ExactDir('/etc')])
+
+        self.checkTrue('/etc')
+
+        self.checkFalse('/')
+        self.checkFalse('/etc/passwd')
+        self.checkFalse('/etc/shadow')
+
+    def test_recursive_dir(self):
+        self.fs = FilesystemPolicy([RecursiveDir('/usr')])
+
+        self.checkTrue('/usr')
+        self.checkTrue('/usr/lib')
+        self.checkTrue('/usr/lib/a/b/c/d/e')
+
+        self.checkFalse('/')
+        self.checkFalse('/etc')
+        self.checkFalse('/us')
+        self.checkFalse('/usr2')
+
+    def test_exact_file(self):
+        self.fs = FilesystemPolicy([ExactFile('/etc/passwd')])
+
+        self.checkTrue('/etc/passwd')
+
+        self.checkFalse('/')
+        self.checkFalse('/etc')
+        self.checkFalse('/etc/p')
+        self.checkFalse('/etc/passwd2')
+
+    def test_path_checks(self):
+        self.fs = FilesystemPolicy([])
+
+        self.assertRaises(AssertionError, self.check, '')
+        self.assertRaises(AssertionError, self.check, 'not/an/absolute/path')
+        self.assertRaises(AssertionError, self.check, '/usr/lib/not/./a/../normalized/path')
+
+    def test_rule_type_check(self):
+        self.assertRaises(AssertionError, FilesystemPolicy, [ExactFile('/usr/lib')])
+        self.assertRaises(AssertionError, FilesystemPolicy, [ExactDir('/etc/passwd')])
+        self.assertRaises(AssertionError, FilesystemPolicy, [RecursiveDir('/etc/passwd')])
+
+    def test_build_checks(self):
+        self.assertRaises(AssertionError, FilesystemPolicy, [ExactFile('not/an/absolute/path')])
+        self.assertRaises(AssertionError, FilesystemPolicy, [ExactDir('/nota/./normalized/path')])
+        self.assertRaises(AssertionError, FilesystemPolicy, [RecursiveDir('')])
+
+    def check(self, path):
+        self.fs.check(path)
+
+    def checkTrue(self, path):
+        self.assertTrue(self.fs.check(path))
+
+    def checkFalse(self, path):
+        self.assertFalse(self.fs.check(path))

--- a/dmoj/utils/helper_files.py
+++ b/dmoj/utils/helper_files.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 
+from dmoj.cptbox.filesystem_policies import RecursiveDir
 from dmoj.error import InternalError
 from dmoj.result import Result
 from dmoj.utils.os_ext import strsignal
@@ -41,7 +42,7 @@ def compile_with_auxiliary_files(filenames, flags=[], lang=None, compiler_time_l
 
     executor = executor.Executor
 
-    kwargs = {'fs': executor.fs + [tempfile.gettempdir()]}
+    kwargs = {'fs': executor.fs + [RecursiveDir(tempfile.gettempdir())]}
 
     if issubclass(executor, CompiledExecutor):
         kwargs['compiler_time_limit'] = compiler_time_limit


### PR DESCRIPTION
This is the first step of migrating to Landlock support. A very simplistic implementation is given here.