### PR TITLE
Detect WSL 1 and apply waitpid hack to it only

### DIFF
--- a/dmoj/cptbox/ptproc.cpp
+++ b/dmoj/cptbox/ptproc.cpp
@@ -121,8 +121,8 @@ int pt_process::monitor() {
     while (true) {
         clock_gettime(CLOCK_MONOTONIC, &start);
 
-#ifdef WSL
-        // WSL currently doesn't support waiting on process groups.
+#ifdef WSL1
+        // WSL1 currently doesn't support waiting on process groups.
         // Hence, we must assume there is only one subprocess at all times.
         // This assumption is valid for normal case of DMOJ usage.
         pid = wait4(-1, &status, __WALL, &_rusage);

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ has_pyx = os.path.exists(os.path.join(os.path.dirname(__file__), 'dmoj', 'cptbox
 
 try:
     with open('/proc/version') as f:
-        is_wsl = 'microsoft' in f.read().lower()
+        is_wsl1 = 'Microsoft' in f.read()
 except IOError:
-    is_wsl = False
+    is_wsl1 = False
 
-# Allow manually disabling seccomp on old kernels. WSL doesn't have seccomp.
-has_seccomp = sys.platform.startswith('linux') and not is_wsl and os.environ.get('DMOJ_USE_SECCOMP') != 'no'
+# Allow manually disabling seccomp on old kernels. WSL 1 doesn't have seccomp.
+has_seccomp = sys.platform.startswith('linux') and not is_wsl1 and os.environ.get('DMOJ_USE_SECCOMP') != 'no'
 try:
     parallel = int(os.environ['DMOJ_PARALLEL'])
 except (KeyError, ValueError):
@@ -141,8 +141,8 @@ if sys.platform.startswith('freebsd'):
     libs += ['procstat']
 
 macros = []
-if is_wsl:
-    macros.append(('WSL', None))
+if is_wsl1:
+    macros.append(('WSL1', None))
 
 if not has_seccomp:
     print('*' * 79)


### PR DESCRIPTION
It appears that WSL 1 uses capitalized "Microsoft" while WSL2 doesn't,
and this is used to distinguish between the WSL versions.