### PR TITLE
testsuite: add test to make sure ENOENT is generated

### DIFF
--- a/testsuite/helloworld/tests/py3_bad_file/helloworld.py
+++ b/testsuite/helloworld/tests/py3_bad_file/helloworld.py
@@ -1,0 +1,2 @@
+with open('/dev/full') as f:
+    print('Hello, World!')

--- a/testsuite/helloworld/tests/py3_bad_file/test.yml
+++ b/testsuite/helloworld/tests/py3_bad_file/test.yml
@@ -1,0 +1,6 @@
+language: PY3
+time: 2
+memory: 65536
+source: helloworld.py
+expect: IR
+feedback: PermissionError


### PR DESCRIPTION
`/dev/full` is is a device file that exists and can be opened by all users, but not actually useful and never actually used:

```console
$ ls -l /dev/full 
crw-rw-rw- 1 root root 1, 7 Aug 22 05:43 /dev/full
```