### PR TITLE
cptbox: use generic errno setter

### DIFF
--- a/dmoj/cptbox/_cptbox.pyx
+++ b/dmoj/cptbox/_cptbox.pyx
@@ -30,6 +30,8 @@ cdef extern from 'ptbox.h' nogil:
         int syscall(int)
         long result()
         void result(long)
+        long error()
+        void error(long)
         long arg0()
         long arg1()
         long arg2()
@@ -269,6 +271,14 @@ cdef class Debugger:
     @uresult.setter
     def uresult(self, value):
         self.thisptr.result(<long><unsigned long>value)
+
+    @property
+    def errno(self):
+        return <long>self.thisptr.error()
+
+    @errno.setter
+    def errno(self, value):
+        self.thisptr.error(<long>value)
 
     @property
     def arg0(self):

--- a/dmoj/cptbox/handlers.py
+++ b/dmoj/cptbox/handlers.py
@@ -9,7 +9,7 @@ STDOUTERR = 3
 def errno_handler(code):
     def handler(debugger):
         def on_return():
-            debugger.result = -code
+            debugger.errno = code
 
         debugger.syscall = -1
         debugger.on_return(on_return)

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -151,6 +151,8 @@ public:
     int syscall(int);
     long result();
     void result(long);
+    long error(); // would name this errno, but it conflicts with the errno macro
+    void error(long);
     long arg0();
     long arg1();
     long arg2();

--- a/dmoj/cptbox/ptdebug.cpp
+++ b/dmoj/cptbox/ptdebug.cpp
@@ -110,6 +110,17 @@ int pt_debugger::post_syscall() {
     return 0;
 }
 
+#if !PTBOX_FREEBSD
+long pt_debugger::error() {
+    long res = result();
+    return res >= -4096 && res < 0 ? -res : 0;
+}
+
+void pt_debugger::error(long value) {
+    result(-value);
+}
+#endif
+
 #if PTBOX_FREEBSD
 typedef int ptrace_read_t;
 #else


### PR DESCRIPTION
This allows errno to be set correctly on FreeBSD.