### PR TITLE
add flake8-import-order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: 3.9
     - name: Install Black and Flake8
       run: |
-        pip install black==19.3b0 flake8 flake8-future-import flake8-logging-format
+        pip install black==19.3b0 flake8 flake8-future-import flake8-logging-format flake8-import-order
     - name: Run Flake8
       run: |
         black --version

--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -4,10 +4,9 @@ import re
 import sys
 
 from dmoj.cptbox._cptbox import AT_FDCWD, bsd_get_proc_cwd, bsd_get_proc_fdno
-from dmoj.cptbox.tracer import MaxLengthExceeded
 from dmoj.cptbox.handlers import ACCESS_EACCES, ACCESS_ENAMETOOLONG, ACCESS_ENOENT, ACCESS_EPERM, ALLOW
-
 from dmoj.cptbox.syscalls import *
+from dmoj.cptbox.tracer import MaxLengthExceeded
 from dmoj.utils.unicode import utf8text
 
 log = logging.getLogger('dmoj.security')

--- a/dmoj/cptbox/tracer.py
+++ b/dmoj/cptbox/tracer.py
@@ -10,9 +10,9 @@ from typing import List, Optional
 
 from dmoj.cptbox._cptbox import *
 from dmoj.cptbox.handlers import ALLOW, DISALLOW, _CALLBACK
-from dmoj.cptbox.syscalls import SYSCALL_COUNT, by_id, translator, sys_exit, sys_exit_group, sys_getpid
+from dmoj.cptbox.syscalls import SYSCALL_COUNT, by_id, sys_exit, sys_exit_group, sys_getpid, translator
 from dmoj.utils.communicate import safe_communicate as _safe_communicate
-from dmoj.utils.os_ext import find_exe_in_path, oom_score_adj, OOM_SCORE_ADJ_MAX
+from dmoj.utils.os_ext import OOM_SCORE_ADJ_MAX, find_exe_in_path, oom_score_adj
 from dmoj.utils.unicode import utf8bytes, utf8text
 
 PIPE = subprocess.PIPE

--- a/dmoj/executors/asm_executor.py
+++ b/dmoj/executors/asm_executor.py
@@ -2,7 +2,7 @@ import os
 import re
 from typing import List, Optional
 
-from dmoj.cptbox import PTBOX_ABI_X86, PTBOX_ABI_X64, can_debug
+from dmoj.cptbox import PTBOX_ABI_X64, PTBOX_ABI_X86, can_debug
 from dmoj.executors.compiled_executor import CompiledExecutor
 from dmoj.judgeenv import env, skip_self_test
 from dmoj.utils.unicode import utf8text

--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 import logging
+import multiprocessing
 import os
 import signal
 import sys
-import multiprocessing
 import threading
 import traceback
 from enum import Enum

--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -7,8 +7,6 @@ from typing import Dict, List, Set
 import yaml
 
 from dmoj.config import ConfigNode
-
-# noinspection PyUnresolvedReferences
 from dmoj.utils import pyyaml_patch  # noqa: F401, imported for side effect
 from dmoj.utils.unicode import utf8text
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-watchdog
-pyyaml
-termcolor
 cython
-pygments
-setproctitle
+flake8-import-order
 pylru
+pygments
+pyyaml
+setproctitle
+termcolor
+watchdog

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cython
-flake8-import-order
 pylru
 pygments
 pyyaml


### PR DESCRIPTION
This adds the package `flake8-import-order` (https://github.com/PyCQA/flake8-import-order), in order to check for import ordering in flake8. It also fixes any current ordering errors.