### PR TITLE
cptbox: make return callbacks work with seccomp

### DIFF
--- a/dmoj/cptbox/tracer.py
+++ b/dmoj/cptbox/tracer.py
@@ -29,6 +29,7 @@ _SYSCALL_INDICIES[PTBOX_ABI_FREEBSD_X64] = 4
 _SYSCALL_INDICIES[PTBOX_ABI_ARM64] = 5
 
 FREEBSD = sys.platform.startswith('freebsd')
+BAD_SECCOMP = sys.platform == 'linux' and tuple(map(int, os.uname().release.partition('-')[0].split('.'))) < (4, 8)
 
 _address_bits = {
     PTBOX_ABI_X86: 32,
@@ -111,6 +112,10 @@ class TracedPopen(Process):
     ):
         self._executable = executable
         self.use_seccomp = security is not None and not avoid_seccomp
+
+        if self.use_seccomp and BAD_SECCOMP:
+            log.warning('Requires Linux 4.8+ to use seccomp, you have: %s', os.uname().release)
+            self.use_seccomp = False
 
         self._args = args
         self._chdir = cwd


### PR DESCRIPTION
We used to invoke the handler immediately after the syscall, but that's imperfect. Instead, we use the Linux 4.8+ behaviour that allows us to receive a syscall-exit-stop right after `PTRACE_EVENT_SECCOMP`, allowing us to implement `on_return` for real.

Naturally, this disables seccomp on kernels before 4.8.