### PR TITLE
executors: disallow /dev/std{in,err,out}

### DIFF
--- a/dmoj/executors/mixins.py
+++ b/dmoj/executors/mixins.py
@@ -32,7 +32,7 @@ BASE_FILESYSTEM = [
     ExactDir('/'),
 ]
 
-BASE_WRITE_FILESYSTEM = [ExactFile('/dev/stdout'), ExactFile('/dev/stderr'), ExactFile('/dev/null')]
+BASE_WRITE_FILESYSTEM = [ExactFile('/dev/null')]
 
 
 if 'freebsd' in sys.platform:


### PR DESCRIPTION
These files are not POSIX, so runtimes should not be relying on their
presence.