### PR TITLE
Change EPERM into EACCES for file access

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -293,10 +293,10 @@ class IsolateTracer(dict):
                     normalized,
                     real,
                 )
-                return file, ACCESS_EPERM
+                return file, ACCESS_EACCES
 
         if not fs_jail.check(normalized):
-            return normalized, ACCESS_EPERM
+            return normalized, ACCESS_EACCES
 
         if normalized != real:
             proc_dir = f'/proc/{debugger.pid}'
@@ -304,7 +304,7 @@ class IsolateTracer(dict):
                 real = os.path.join('/proc/self', os.path.relpath(real, proc_dir))
 
             if not fs_jail.check(real):
-                return real, ACCESS_EPERM
+                return real, ACCESS_EACCES
 
         return real, None
 


### PR DESCRIPTION
Landlock returns this, not EPERM.