### PR TITLE
fix java executors VM config detection

### DIFF
--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -1,4 +1,5 @@
 import errno
+import glob
 import os
 import re
 import subprocess
@@ -84,7 +85,8 @@ class JavaExecutor(SingleDigitVersionMixin, CompiledExecutor):
             + [ExactFile(self._agent_file)]
             + [ExactDir(str(parent)) for parent in PurePath(self._agent_file).parents]
         )
-        vm_config = Path(self.get_vm()).parent.parent / 'lib' / 'jvm.cfg'
+        vm_parent = Path(os.path.realpath(self.get_vm())).parent.parent
+        vm_config = Path(glob.glob(f'{vm_parent}/**/jvm.cfg', recursive=True)[0])
         if vm_config.is_symlink():
             fs += [RecursiveDir(os.path.dirname(os.path.realpath(vm_config)))]
         return fs


### PR DESCRIPTION
previously, an erroneous directory was chosen for the JVM config. To 
ensure a good path is chosen, we use a glob, and resolve the VM path.