### PR TITLE
cptbox: drop support for FreeBSD < 8

### DIFF
--- a/dmoj/cptbox/helper.cpp
+++ b/dmoj/cptbox/helper.cpp
@@ -232,10 +232,8 @@ static inline void cptbox_closefrom_getdents(int lowfd) {
 #endif
 
 void cptbox_closefrom(int lowfd) {
-#if defined(__FreeBSD__) && __FreeBSD__ >= 8
+#if defined(__FreeBSD__)
     closefrom(lowfd);
-#elif defined(F_CLOSEM)
-    fcntl(fd, F_CLOSEM, 0);
 #elif defined(__linux__)
     cptbox_closefrom_getdents(lowfd);
 #else


### PR DESCRIPTION
The fcntl(F_CLOSEM) approach is only needed for FreeBSD releases out of
support for over 6 years, and the code path doesn't even work as it used
the wrong variable name.