### PR TITLE
cptbox: ignore ESRCH from post_syscall handler

### DIFF
--- a/dmoj/cptbox/ptproc.cpp
+++ b/dmoj/cptbox/ptproc.cpp
@@ -271,6 +271,14 @@ int pt_process::monitor() {
             }
 
             if ((err = debugger->post_syscall()) != 0) {
+#if !PTBOX_FREEBSD
+                // Again, it is possible for the process to be killed between pre_syscall and post_syscall.
+                // We ignore ESRCH in such a case.
+                if (err == ESRCH) {
+                    fprintf(stderr, "thread disappeared: %d, ignoring.\n", pid);
+                    continue;
+                }
+#endif
                 dispatch(PTBOX_EVENT_PTRACE_ERROR, err);
                 exit_reason = protection_fault(syscall, PTBOX_EVENT_UPDATE_FAIL);
                 continue;


### PR DESCRIPTION
This deals with flakiness when a child process gets killed on Linux, which
manifests as randomly failing Go compiles. Since Go is not INTERCAL, we
strive to avoid such "random compiler bugs".