### PR TITLE
cptbox: correctly handle sys_execve being allowed with seccomp

### DIFF
--- a/dmoj/cptbox/tracer.py
+++ b/dmoj/cptbox/tracer.py
@@ -10,7 +10,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Type
 
 from dmoj.cptbox._cptbox import *
 from dmoj.cptbox.handlers import ALLOW, DISALLOW, ErrnoHandlerCallback, _CALLBACK
-from dmoj.cptbox.syscalls import SYSCALL_COUNT, by_id, sys_exit, sys_exit_group, sys_getpid, translator
+from dmoj.cptbox.syscalls import SYSCALL_COUNT, by_id, sys_execve, sys_exit, sys_exit_group, sys_getpid, translator
 from dmoj.utils.communicate import safe_communicate as _safe_communicate
 from dmoj.utils.os_ext import OOM_SCORE_ADJ_MAX, oom_score_adj
 from dmoj.utils.unicode import utf8bytes, utf8text
@@ -184,9 +184,9 @@ class TracedPopen(Process):
         index = _SYSCALL_INDICIES[NATIVE_ABI]
         assert index is not None
         for i in range(SYSCALL_COUNT):
-            # Ensure at least one syscall traps.
+            # Ensure at least one syscall traps, including the execve so we know the process started.
             # Otherwise, a simple assembly program could terminate without ever trapping.
-            if i in (sys_exit, sys_exit_group):
+            if i in (sys_execve, sys_exit, sys_exit_group):
                 continue
             handler = self._security.get(i, DISALLOW)
             for call in translator[i][index]:

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -88,16 +88,12 @@ class CompilerIsolateTracer(IsolateTracer):
         write_fs += BASE_WRITE_FILESYSTEM + [RecursiveDir(tmpdir)]
         super().__init__(read_fs, *args, write_fs=write_fs, **kwargs)
 
-        # FIXME: big hack to force execve to be handled even with seccomp.
-        def handle_execve(debugger):
-            return True
-
         self.update(
             {
                 # Process spawning system calls
                 sys_fork: ALLOW,
                 sys_vfork: ALLOW,
-                sys_execve: handle_execve,
+                sys_execve: ALLOW,
                 # Directory system calls
                 sys_mkdir: self.check_file_access('mkdir', 0, is_write=True),
                 sys_mkdirat: self.check_file_access_at('mkdirat', is_write=True),


### PR DESCRIPTION
This avoids the hack of using a callback that returns True.