### PR TITLE
testsuite: reduce memory limit for C# MLE test

### DIFF
--- a/testsuite/helloworld/tests/monocs_mle/test.posix.yml
+++ b/testsuite/helloworld/tests/monocs_mle/test.posix.yml
@@ -1,5 +1,5 @@
 language: MONOCS
 time: 2
-memory: 10240
+memory: 8192
 source: helloworld.cs
 expect: MLE


### PR DESCRIPTION
This should hopefully avoid flakiness with memory usage on FreeBSD.