### PR TITLE
executors: improve /usr handling

### DIFF
--- a/dmoj/executors/mixins.py
+++ b/dmoj/executors/mixins.py
@@ -13,13 +13,18 @@ from dmoj.judgeenv import env
 from dmoj.utils import setbufsize_path
 from dmoj.utils.unicode import utf8bytes
 
+if os.path.isdir('/usr/home'):
+    USR_DIR = [RecursiveDir(f'/usr/{d}') for d in os.listdir('/usr') if d != 'home' and os.path.isdir(f'/usr/{d}')]
+else:
+    USR_DIR = [RecursiveDir('/usr')]
+
 BASE_FILESYSTEM = [
     ExactFile('/dev/null'),
     ExactFile('/dev/tty'),
     ExactFile('/dev/zero'),
     ExactFile('/dev/urandom'),
     ExactFile('/dev/random'),
-    *[RecursiveDir(f'/usr/{d}') for d in os.listdir('/usr') if d != 'home' and os.path.isdir(f'/usr/{d}')],
+    *USR_DIR,
     RecursiveDir('/lib'),
     RecursiveDir('/lib32'),
     RecursiveDir('/lib64'),


### PR DESCRIPTION
On some platforms, e.g. arm64, gcc tries to look for non-existent
directories under /usr, and complains when forbidden to do so. To fix this,
we must allow the entirety of /usr.

The only reason we don't allow the entirety of /usr is because on FreeBSD,
home directories are located in /usr/home. However, this is easily fixed
by using the current logic if /usr/home exists, and otherwise allow
everything under /usr.