### PR TITLE
config: fix ConfigNode.get fallback logic

### DIFF
--- a/dmoj/config.py
+++ b/dmoj/config.py
@@ -68,7 +68,7 @@ class ConfigNode:
         raise InvalidInitException('config node is not a dict')
 
     def get(self, key, default=None):
-        return self[key] or default
+        return self[key] if key in self else default
 
     def items(self):
         return self.iteritems()


### PR DESCRIPTION
Currently, it is impossible to store `null` in the YAML config file to
override a non-null default value, as it will always fallback due to
the or.

This manifests as broken `-march=native` removal for gcc/clang.