### PR TITLE
executors: use shutil.which instead of deprecated distutils

### DIFF
--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 import tempfile
 import traceback
-from distutils.spawn import find_executable
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from dmoj.cptbox import IsolateTracer, TracedPopen, syscalls
@@ -413,7 +412,7 @@ class BaseExecutor:
                 if os.path.exists(file):
                     return file
             else:
-                path = find_executable(file)
+                path = shutil.which(file)
                 if path is not None:
                     return os.path.abspath(path)
         return None

--- a/dmoj/executors/shell_executor.py
+++ b/dmoj/executors/shell_executor.py
@@ -1,6 +1,6 @@
 import os
+import shutil
 import sys
-from distutils.spawn import find_executable
 
 from dmoj.executors.script_executor import ScriptExecutor
 
@@ -13,7 +13,7 @@ class ShellExecutor(ScriptExecutor):
         return self.shell_commands
 
     def get_allowed_exec(self):
-        return list(map(find_executable, self.get_shell_commands()))
+        return list(map(shutil.which, self.get_shell_commands()))
 
     def get_fs(self):
         return super().get_fs() + self.get_allowed_exec()


### PR DESCRIPTION
See [PEP 632](https://www.python.org/dev/peps/pep-0632/#migration-advice), which suggests replacing `distutils.spawn.find_executable` with `shutil.which`.