### PR TITLE
ci: allow less executors to fail

### DIFF
--- a/.docker.test.py
+++ b/.docker.test.py
@@ -10,6 +10,7 @@ ALLOW_FAIL = {'GASARM', 'JAVA9', 'JAVA10', 'OBJC'}
 EXECUTORS = get_available()
 
 if arch == 'aarch64':
+    ALLOW_FAIL -= {'GASARM'}
     ALLOW_FAIL |= {'D', 'GAS32', 'GAS64', 'NASM', 'NASM64', 'SWIFT', 'TUR'}
 elif arch != 'x86_64':
     raise AssertionError('invalid architecture')

--- a/.docker.test.py
+++ b/.docker.test.py
@@ -6,7 +6,7 @@ from dmoj.citest import ci_test
 from dmoj.executors import get_available
 
 arch = platform.machine()
-ALLOW_FAIL = {'GASARM', 'JAVA9', 'JAVA10', 'OBJC', 'GROOVY'}
+ALLOW_FAIL = {'GASARM', 'JAVA9', 'JAVA10', 'OBJC'}
 EXECUTORS = get_available()
 
 if arch == 'aarch64':


### PR DESCRIPTION
Groovy is expected to be permanently fixed with the removal of Java security managers, and GASARM works now on arm64.