### PR TITLE
executors/PAS: drop -So argument

### DIFF
--- a/dmoj/executors/PAS.py
+++ b/dmoj/executors/PAS.py
@@ -19,7 +19,7 @@ end.
 """
 
     def get_compile_args(self):
-        return [self.get_command(), '-Fe/dev/stderr', '-So', '-O2', self._code]
+        return [self.get_command(), '-Fe/dev/stderr', '-O2', self._code]
 
     def get_compile_output(self, process):
         output = super().get_compile_output(process)


### PR DESCRIPTION
This was inherited from PEG, but doesn't seem to be specified by other
online judges.

    -So
        Try to be Borland TP 7.0 compatible (no function overloading etc.).