### PR TITLE
cptbox: allow statx by default

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -59,6 +59,7 @@ class IsolateTracer(dict):
                 sys_lstat: self.check_file_access('lstat', 0),
                 sys_lstat64: self.check_file_access('lstat64', 0),
                 sys_fstatat: self.check_file_access_at('fstatat'),
+                sys_statx: self.check_file_access_at('statx'),
                 sys_tgkill: self.do_kill,
                 sys_kill: self.do_kill,
                 sys_prctl: self.do_prctl,

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -108,7 +108,6 @@ class CompilerIsolateTracer(IsolateTracer):
                 sys_chdir: self.check_file_access('chdir', 0),
                 sys_chmod: self.check_file_access('chmod', 0, is_write=True),
                 sys_utimensat: self.do_utimensat,
-                sys_statx: self.check_file_access_at('statx'),
                 sys_umask: ALLOW,
                 sys_flock: ALLOW,
                 sys_fsync: ALLOW,


### PR DESCRIPTION
It used to only be allowed for compilers, but there is no reason why
it should be compiler-only given that other stat syscalls are allowed
for everything.

This will fix the failure with Turing on latest glibc.