### PR TITLE
Add executor for Lean 4

### DIFF
--- a/.docker.test.py
+++ b/.docker.test.py
@@ -6,7 +6,7 @@ from dmoj.citest import ci_test
 from dmoj.executors import get_available
 
 arch = platform.machine()
-ALLOW_FAIL = {'GASARM', 'JAVA9', 'JAVA10', 'OBJC'}
+ALLOW_FAIL = {'GASARM', 'JAVA9', 'JAVA10', 'LEAN4', 'OBJC'}
 EXECUTORS = get_available()
 
 if arch == 'aarch64':

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The judge can also grade in the languages listed below. These languages are less
 * Haskell
 * INTERCAL
 * Kotlin
+* Lean 4
 * Lua
 * NASM
 * Objective-C

--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -285,6 +285,10 @@ class IsolateTracer(dict):
         if normalized.startswith('/proc/self'):
             file = os.path.join(f'/proc/{debugger.tid}', os.path.relpath(file, '/proc/self'))
             projected = '/' + os.path.normpath(file).lstrip('/')
+        elif normalized.startswith(f'/proc/{debugger.tid}/'):
+            # If the child process uses /proc/getpid()/foo, set the normalized path to be /proc/self/foo.
+            # Access rules can more easily check /proc/self.
+            normalized = os.path.join('/proc/self', os.path.relpath(file, f'/proc/{debugger.tid}'))
         real = os.path.realpath(file)
 
         try:

--- a/dmoj/executors/LEAN4.py
+++ b/dmoj/executors/LEAN4.py
@@ -1,14 +1,9 @@
-from dmoj.cptbox.filesystem_policies import RecursiveDir
 from dmoj.executors.compiled_executor import CompiledExecutor
 
 
 class Executor(CompiledExecutor):
     ext = 'lean'
     command = 'lean'
-    compiler_read_fs = [
-        # needed due to snprintf(path, PATH_MAX, "/proc/%d/exe", pid)
-        RecursiveDir('/proc'),
-    ]
     test_program = """
 def main : IO Unit := do
   let cin ← IO.getStdin
@@ -17,15 +12,17 @@ def main : IO Unit := do
 """
 
     def compile(self) -> str:
-        # lean -c f2.c f1.lean && leanc -o f3 f2.c -O3 -DNDEBUG
         command = self.get_command()
         assert command is not None
         assert self._code is not None
         c_file = f'{self.problem}.c'
+
+        # lean -c f2.c f1.lean && leanc -o f3 f2.c -O3 -DNDEBUG
         proc1 = self.create_compile_process([command, '-c', c_file, self._code])
         out1 = self.get_compile_output(proc1)
         proc2 = self.create_compile_process([f'{command}c', '-o', self.problem, c_file, '-O3', '-DNDEBUG'])
         out2 = self.get_compile_output(proc2)
+
         self.warning = b'\n'.join(filter(None, [out1, out2]))
         self._executable = self.get_compiled_file()
         return self._executable

--- a/dmoj/executors/LEAN4.py
+++ b/dmoj/executors/LEAN4.py
@@ -18,10 +18,13 @@ def main : IO Unit := do
 
     def compile(self) -> str:
         # lean -c f2.c f1.lean && leanc -o f3 f2.c -O3 -DNDEBUG
+        command = self.get_command()
+        assert command is not None
+        assert self._code is not None
         c_file = f'{self.problem}.c'
-        proc1 = self.create_compile_process([self.get_command(), '-c', c_file, self._code])  # type: ignore
+        proc1 = self.create_compile_process([command, '-c', c_file, self._code])
         out1 = self.get_compile_output(proc1)
-        proc2 = self.create_compile_process([f'{self.get_command()}c', '-o', self.problem, c_file, '-O3', '-DNDEBUG'])
+        proc2 = self.create_compile_process([f'{command}c', '-o', self.problem, c_file, '-O3', '-DNDEBUG'])
         out2 = self.get_compile_output(proc2)
         self.warning = b'\n'.join(filter(None, [out1, out2]))
         self._executable = self.get_compiled_file()

--- a/dmoj/executors/LEAN4.py
+++ b/dmoj/executors/LEAN4.py
@@ -19,7 +19,7 @@ def main : IO Unit := do
     def compile(self) -> str:
         # lean -c f2.c f1.lean && leanc -o f3 f2.c -O3 -DNDEBUG
         c_file = f'{self.problem}.c'
-        proc1 = self.create_compile_process([self.get_command(), '-c', c_file, self._code])
+        proc1 = self.create_compile_process([self.get_command(), '-c', c_file, self._code])  # type: ignore
         out1 = self.get_compile_output(proc1)
         proc2 = self.create_compile_process([f'{self.get_command()}c', '-o', self.problem, c_file, '-O3', '-DNDEBUG'])
         out2 = self.get_compile_output(proc2)

--- a/dmoj/executors/LEAN4.py
+++ b/dmoj/executors/LEAN4.py
@@ -1,0 +1,28 @@
+from dmoj.cptbox.filesystem_policies import RecursiveDir
+from dmoj.executors.compiled_executor import CompiledExecutor
+
+
+class Executor(CompiledExecutor):
+    ext = 'lean'
+    command = 'lean'
+    compiler_read_fs = [
+        # needed due to snprintf(path, PATH_MAX, "/proc/%d/exe", pid)
+        RecursiveDir('/proc'),
+    ]
+    test_program = """
+def main : IO Unit := do
+  let cin ← IO.getStdin
+  let line ← cin.getLine
+  IO.println line
+"""
+
+    def compile(self) -> str:
+        # lean -c f2.c f1.lean && leanc -o f3 f2.c -O3 -DNDEBUG
+        c_file = f'{self.problem}.c'
+        proc1 = self.create_compile_process([self.get_command(), '-c', c_file, self._code])
+        out1 = self.get_compile_output(proc1)
+        proc2 = self.create_compile_process([f'{self.get_command()}c', '-o', self.problem, c_file, '-O3', '-DNDEBUG'])
+        out2 = self.get_compile_output(proc2)
+        self.warning = b'\n'.join(filter(None, [out1, out2]))
+        self._executable = self.get_compiled_file()
+        return self._executable


### PR DESCRIPTION
Coq can't do I/O. Agda requires a resource-intensive command `cabal install Agda`. Lean 3 can't generate an executable (but it can compile `.lean` to `.olean` for a performance boost). The next best language is Lean 4.

How to test this:
- Install Lean 4 to `/opt/lean`
  ```bash
  mkdir /opt/lean
  curl --compressed -L "https://github.com/leanprover/lean4/releases/download/v4.0.0-m2/lean-4.0.0-m2-linux.tar.gz" | tar xz -C /opt/lean --strip-components=1
  export PATH="/opt/lean/bin:$PATH"
  ```
- Modify `.docker.test.py` and `dmoj/citest.py` to just test `LEAN4`
- ![Capture](https://user-images.githubusercontent.com/14223529/148033474-720f5397-e20c-492b-86c1-fffca498ec4e.PNG)
  (nit: the version is actually `4.0.0-m2`)

(Lean 4 has some support for siggrading, so it's possible to host a theorem proving contest)