### PR TITLE
ci: improve automatic syscall PR generation

### DIFF
--- a/.github/workflows/update-syscalls.yml
+++ b/.github/workflows/update-syscalls.yml
@@ -22,8 +22,8 @@ jobs:
         token: ${{ secrets.REPO_SCOPED_TOKEN }}
         author: dmoj-build <build@dmoj.ca>
         committer: dmoj-build <build@dmoj.ca>
-        commit-message: 'cptbox: update Linux syscall list'
-        title: 'Update Linux syscall list'
+        commit-message: 'cptbox: update syscall lists'
+        title: 'Update syscall lists'
         body: This PR has been auto-generated to update the syscall definitions in `cptbox`.
         labels: cptbox, security, enhancement
         reviewers: Xyene, quantum5

--- a/dmoj/cptbox/syscalls/generate.py
+++ b/dmoj/cptbox/syscalls/generate.py
@@ -123,10 +123,6 @@ with open('aliases.list') as aliases:
     for line in aliases:
         names.add(line.split()[1])
 
-with open('freebsd.tbl') as freebsd:
-    for line in freebsd:
-        names.add(line.split()[1])
-
 with open('../syscalls.pyi', 'w') as interface:
     print(
         """\


### PR DESCRIPTION
Basically don't say Linux in the PR title or commit message since we generate FreeBSD too now.