### PR TITLE
cptbox: make `_file_access_check` syscall-agnostic

### DIFF
--- a/dmoj/cptbox/__init__.py
+++ b/dmoj/cptbox/__init__.py
@@ -1,5 +1,5 @@
 from dmoj.cptbox._cptbox import Debugger, PTBOX_ABI_ARM, PTBOX_ABI_ARM64, PTBOX_ABI_X32, PTBOX_ABI_X64, PTBOX_ABI_X86
 from dmoj.cptbox.handlers import ALLOW, DISALLOW
-from dmoj.cptbox.isolate import IsolateTracer
+from dmoj.cptbox.isolate import FilesystemSyscallKind, IsolateTracer
 from dmoj.cptbox.syscalls import SYSCALL_COUNT
 from dmoj.cptbox.tracer import PIPE, TracedPopen, can_debug

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -100,7 +100,7 @@ class CompilerIsolateTracer(IsolateTracer):
                 sys_rmdir: self.check_file_access('rmdir', 0, FilesystemSyscallKind.WRITE),
                 # Linking system calls
                 sys_link: self.check_file_access('link', 1, FilesystemSyscallKind.WRITE),
-                sys_linkat: self.check_file_access_at('linkat', FilesystemSyscallKind.WRITE, argument=3),
+                sys_linkat: self.check_file_access_at('linkat', FilesystemSyscallKind.WRITE, file_reg=3),
                 sys_unlink: self.check_file_access('unlink', 0, FilesystemSyscallKind.WRITE),
                 sys_unlinkat: self.check_file_access_at('unlinkat', FilesystemSyscallKind.WRITE),
                 sys_symlink: self.check_file_access('symlink', 1, FilesystemSyscallKind.WRITE),


### PR DESCRIPTION
It was confusing that it was handling both `open`/`fstat` in non-obvious
ways.