### PR TITLE
executors: add support for Ruby 3

### DIFF
--- a/.freebsd.test.py
+++ b/.freebsd.test.py
@@ -22,7 +22,7 @@ EXECUTORS = [
     'PERL',
     'PY2',
     'PY3',
-    'RUBY2',
+    'RUBY',
     'SED',
     'TEXT',
 ]
@@ -33,7 +33,7 @@ def main():
     judgeenv.env['runtime'] = {}
     judgeenv.env['extra_fs'] = {
         'PERL': [{'exact_file': '/dev/dtrace/helper'}],
-        'RUBY2': [{'exact_file': '/dev/dtrace/helper'}],
+        'RUBY': [{'exact_file': '/dev/dtrace/helper'}],
     }
 
     logging.basicConfig(level=logging.INFO)

--- a/dmoj/executors/RUBY.py
+++ b/dmoj/executors/RUBY.py
@@ -10,7 +10,9 @@ class Executor(ScriptExecutor):
     address_grace = 65536
     test_program = 'puts gets'
     nproc = -1
-    command_paths = ['ruby2.%d' % i for i in reversed(range(0, 8))] + ['ruby2%d' % i for i in reversed(range(0, 8))]
+    command_paths = (
+        ['ruby3.0'] + ['ruby2.%d' % i for i in reversed(range(0, 8))] + ['ruby2%d' % i for i in reversed(range(0, 8))]
+    )
     syscalls = ['thr_set_name', 'eventfd2', 'specialfd']
     fs = [ExactFile('/proc/self/loginuid')]
 


### PR DESCRIPTION
Ruby 2 -> 3 is not a breaking change, so rename the executor to just
`RUBY` and add `ruby3.0` to the search path.