### PR TITLE
testsuite: add test for opening format string

### DIFF
--- a/testsuite/helloworld/tests/sandbox_c_format_open/format_open.c
+++ b/testsuite/helloworld/tests/sandbox_c_format_open/format_open.c
@@ -1,0 +1,17 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    int fd;
+    if ((fd = open("%s", O_RDONLY)) >= 0) {
+        puts("Should not open the file");
+    } else if (errno == EACCES || errno == ENOENT) { // differs between seccomp and landlock
+        puts("Hello, World!");
+        return 0;
+    } else {
+        printf("Wrong errno: %d", errno);
+    }
+    return -1;
+}

--- a/testsuite/helloworld/tests/sandbox_c_format_open/test.yml
+++ b/testsuite/helloworld/tests/sandbox_c_format_open/test.yml
@@ -1,0 +1,5 @@
+language: C
+time: 1
+memory: 65536
+source: format_open.c
+expect: AC


### PR DESCRIPTION
Raised as a concern in #998. We should add an explicit test for this. Note that on seccomp, this returns EACCES, but on landlock, it will return ENOENT, and conceptually, both are reasonable.