### PR TITLE
executors: remove all regex path checks

### DIFF
--- a/dmoj/executors/OBJC.py
+++ b/dmoj/executors/OBJC.py
@@ -2,6 +2,7 @@ import os
 from subprocess import CalledProcessError, check_output
 from typing import List
 
+from dmoj.cptbox.filesystem_policies import ExactFile
 from dmoj.judgeenv import env
 from .gcc_executor import GCCExecutor
 
@@ -33,7 +34,7 @@ int main (int argc, const char * argv[]) {
         return self.objc_ldflags + super().get_ldflags()
 
     def get_fs(self):
-        return super().get_fs() + [r'/proc/\d+/cmdline$']
+        return super().get_fs() + [ExactFile('/proc/self/cmdline')]
 
     @classmethod
     def initialize(cls):

--- a/dmoj/executors/RUBY.py
+++ b/dmoj/executors/RUBY.py
@@ -1,7 +1,6 @@
 import os
-import re
 
-from dmoj.cptbox.filesystem_policies import ExactFile
+from dmoj.cptbox.filesystem_policies import ExactDir, ExactFile, RecursiveDir
 from dmoj.executors.script_executor import ScriptExecutor
 
 
@@ -20,11 +19,11 @@ class Executor(ScriptExecutor):
         fs = super().get_fs()
         home = self.runtime_dict.get('%s_home' % self.get_executor_name().lower())
         if home is not None:
-            fs.append(re.escape(home))
+            fs.append(RecursiveDir(home))
             components = home.split('/')
             components.pop()
             while components and components[-1]:
-                fs.append(re.escape('/'.join(components)) + '$')
+                fs.append(ExactDir('/'.join(components)))
                 components.pop()
         return fs
 

--- a/dmoj/executors/shell_executor.py
+++ b/dmoj/executors/shell_executor.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
+from dmoj.cptbox.filesystem_policies import ExactFile
 from dmoj.cptbox.isolate import DeniedSyscall, protection_fault
 from dmoj.executors.script_executor import ScriptExecutor
 
@@ -16,7 +17,7 @@ class ShellExecutor(ScriptExecutor):
         return list(map(shutil.which, self.get_shell_commands()))
 
     def get_fs(self):
-        return super().get_fs() + self.get_allowed_exec()
+        return super().get_fs() + list(map(ExactFile, self.get_allowed_exec()))
 
     def get_allowed_syscalls(self):
         return super().get_allowed_syscalls() + ['fork', 'waitpid', 'wait4']


### PR DESCRIPTION
Remove legacy code that added regex strings to the allowed filesystem. Disclaimer: we can't support the regex that OBJC had before, but we can make a best attempt.