### PR TITLE
cptbox + executors: cleanup IsolateTracer signature

### DIFF
--- a/dmoj/cptbox/compiler_isolate.py
+++ b/dmoj/cptbox/compiler_isolate.py
@@ -14,14 +14,14 @@ UTIME_OMIT = (1 << 30) - 2
 
 
 class CompilerIsolateTracer(IsolateTracer):
-    def __init__(self, tmpdir, read_fs, write_fs, *args, **kwargs):
+    def __init__(self, *, tmpdir, read_fs, write_fs):
         read_fs += BASE_FILESYSTEM + [
             RecursiveDir(tmpdir),
             ExactFile('/bin/strip'),
             RecursiveDir('/usr/x86_64-linux-gnu'),
         ]
         write_fs += BASE_WRITE_FILESYSTEM + [RecursiveDir(tmpdir)]
-        super().__init__(read_fs, *args, write_fs=write_fs, **kwargs)
+        super().__init__(read_fs=read_fs, write_fs=write_fs)
 
         self.update(
             {

--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -42,12 +42,10 @@ DirFDGetter = Callable[[Debugger], int]
 
 
 class IsolateTracer(dict):
-    def __init__(self, read_fs, write_fs=None, writable=(1, 2)):
+    def __init__(self, *, read_fs, write_fs):
         super().__init__()
         self.read_fs_jail = self._compile_fs_jail(read_fs)
         self.write_fs_jail = self._compile_fs_jail(write_fs)
-
-        self._writable = list(writable)
 
         if sys.platform.startswith('freebsd'):
             self._getcwd_pid = lambda pid: utf8text(bsd_get_proc_cwd(pid))

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -214,7 +214,7 @@ class BaseExecutor(metaclass=ExecutorMeta):
         return sec
 
     def get_security(self, launch_kwargs=None) -> IsolateTracer:
-        sec = IsolateTracer(self.get_fs(), write_fs=self.get_write_fs())
+        sec = IsolateTracer(read_fs=self.get_fs(), write_fs=self.get_write_fs())
         return self._add_syscalls(sec)
 
     def get_fs(self) -> List[FilesystemAccessRule]:

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -123,7 +123,9 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
             [utf8bytes(a) for a in args],
             **{
                 'executable': utf8bytes(args[0]),
-                'security': CompilerIsolateTracer(self._dir, self.compiler_read_fs, self.compiler_write_fs),
+                'security': CompilerIsolateTracer(
+                    tmpdir=self._dir, read_fs=self.compiler_read_fs, write_fs=self.compiler_write_fs
+                ),
                 'stderr': _slave,
                 'stdout': _slave,
                 'stdin': _slave,


### PR DESCRIPTION
Remove legacy `writable` parameter, and make both `read_fs` and `write_fs` required kwargs. Also make `tmpdir` a required kwarg on CompilerIsolateTracer.