### PR TITLE
cptbox: remove legacy PTBOX_HANDLER_STDOUTERR

### DIFF
--- a/dmoj/cptbox/handlers.py
+++ b/dmoj/cptbox/handlers.py
@@ -5,7 +5,6 @@ from dmoj.cptbox._cptbox import Debugger
 DISALLOW = 0
 ALLOW = 1
 _CALLBACK = 2
-STDOUTERR = 3
 
 
 class ErrnoHandlerCallback:

--- a/dmoj/cptbox/handlers.pyi
+++ b/dmoj/cptbox/handlers.pyi
@@ -3,7 +3,6 @@ from dmoj.cptbox._cptbox import Debugger
 ALLOW: int
 DISALLOW: int
 _CALLBACK: int
-STDOUTERR: int
 
 class ErrnoHandlerCallback:
     errno: int

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -25,11 +25,10 @@
 #include <seccomp.h>
 #endif
 
-#define MAX_SYSCALL             600
-#define PTBOX_HANDLER_DENY      0
-#define PTBOX_HANDLER_ALLOW     1
-#define PTBOX_HANDLER_CALLBACK  2
-#define PTBOX_HANDLER_STDOUTERR 3
+#define MAX_SYSCALL            600
+#define PTBOX_HANDLER_DENY     0
+#define PTBOX_HANDLER_ALLOW    1
+#define PTBOX_HANDLER_CALLBACK 2
 
 #define PTBOX_EVENT_ATTACH       0
 #define PTBOX_EVENT_EXITING      1

--- a/dmoj/cptbox/ptproc.cpp
+++ b/dmoj/cptbox/ptproc.cpp
@@ -228,12 +228,6 @@ int pt_process::monitor() {
                     switch (handler[debugger->abi()][syscall]) {
                         case PTBOX_HANDLER_ALLOW:
                             break;
-                        case PTBOX_HANDLER_STDOUTERR: {
-                            int arg0 = debugger->arg0();
-                            if (arg0 != 1 && arg0 != 2)
-                                exit_reason = protection_fault(syscall);
-                            break;
-                        }
                         case PTBOX_HANDLER_CALLBACK:
                             if (callback(context, syscall))
                                 break;


### PR DESCRIPTION
This is from a time when we trapped `write`, and checked the arguments of it, neither of which is true now.