### PR TITLE
cptbox: add typing and fix typing on rule list

### DIFF
--- a/dmoj/cptbox/filesystem_policies.py
+++ b/dmoj/cptbox/filesystem_policies.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-from typing import List, Union
+from typing import Sequence, Union
 
 
 class AccessMode(Enum):
@@ -47,7 +47,7 @@ FilesystemAccessRule = Union[ExactFile, ExactDir, RecursiveDir]
 
 
 class FilesystemPolicy:
-    def __init__(self, rules: List[FilesystemAccessRule]):
+    def __init__(self, rules: Sequence[FilesystemAccessRule]):
         self.root = Dir()
         for rule in rules:
             self._add_rule(rule)


### PR DESCRIPTION
There were some missing types in the isolate tracer. Since we need only iterate through the list in the Policy constructor, it need not be a list.