### PR TITLE
cptbox: don't allow paths that don't exist

### DIFF
--- a/dmoj/cptbox/filesystem_policies.py
+++ b/dmoj/cptbox/filesystem_policies.py
@@ -80,6 +80,9 @@ class FilesystemPolicy:
             self._add_rule(rule)
 
     def _add_rule(self, rule: FilesystemAccessRule) -> None:
+        if not rule.exists():
+            return
+
         if rule.path == '/':
             return self._finalize_root_rule(rule)
 

--- a/dmoj/executors/SWIFT.py
+++ b/dmoj/executors/SWIFT.py
@@ -9,6 +9,7 @@ class Executor(CompiledExecutor):
         RecursiveDir('~/.cache'),
     ]
     compiler_write_fs = compiler_read_fs
+    compiler_required_dirs = ['~/.cache']
     test_program = 'print(readLine()!)'
 
     def get_compile_args(self):

--- a/dmoj/executors/ZIG.py
+++ b/dmoj/executors/ZIG.py
@@ -10,6 +10,7 @@ class Executor(CompiledExecutor):
         RecursiveDir('~/.cache'),
     ]
     compiler_write_fs = compiler_read_fs
+    compiler_required_dirs = ['~/.cache']
     test_program = """
 const std = @import("std");
 

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -81,6 +81,9 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
     compiler_read_fs: Sequence[FilesystemAccessRule] = []
     compiler_write_fs: Sequence[FilesystemAccessRule] = []
 
+    # List of directories required by the compiler to be present, typically for writing to
+    compiler_required_dirs: List[str] = []
+
     def __init__(self, problem_id: str, source_code: bytes, *args, **kwargs) -> None:
         super().__init__(problem_id, source_code, **kwargs)
         self.warning = None
@@ -94,6 +97,13 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
         self._code = self._file(self.source_filename_format.format(problem_id=problem_id, ext=self.ext))
         with open(self._code, 'wb') as fo:
             fo.write(utf8bytes(source_code))
+
+        for path in self.compiler_required_dirs:
+            path = os.path.expanduser(path)
+            try:
+                os.mkdir(path, mode=0o775)
+            except FileExistsError:
+                pass
 
     def get_compile_args(self) -> List[str]:
         raise NotImplementedError()

--- a/dmoj/tests/test_filesystem_policy.py
+++ b/dmoj/tests/test_filesystem_policy.py
@@ -43,14 +43,14 @@ class CheckerTest(unittest.TestCase):
         self.assertRaises(AssertionError, self.check, '/usr/lib/not/./a/../normalized/path')
 
     def test_rule_type_check(self):
-        self.assertRaises(AssertionError, FilesystemPolicy, [ExactFile('/usr/lib')])
-        self.assertRaises(AssertionError, FilesystemPolicy, [ExactDir('/etc/passwd')])
-        self.assertRaises(AssertionError, FilesystemPolicy, [RecursiveDir('/etc/passwd')])
+        self.assertRaises(AssertionError, ExactFile, '/usr/lib')
+        self.assertRaises(AssertionError, ExactDir, '/etc/passwd')
+        self.assertRaises(AssertionError, RecursiveDir, '/etc/passwd')
 
-    def test_build_checks(self):
-        self.assertRaises(AssertionError, FilesystemPolicy, [ExactFile('not/an/absolute/path')])
-        self.assertRaises(AssertionError, FilesystemPolicy, [ExactDir('/nota/./normalized/path')])
-        self.assertRaises(AssertionError, FilesystemPolicy, [RecursiveDir('')])
+    def test_bad_path_check(self):
+        self.assertRaises(AssertionError, ExactFile, 'not/an/absolute/path')
+        self.assertRaises(AssertionError, ExactDir, '/nota/./normalized/path')
+        self.assertRaises(AssertionError, RecursiveDir, '')
 
     def check(self, path):
         self.fs.check(path)


### PR DESCRIPTION
This is mostly for compatibility with landlock, which enforces this. Builds on top of #999.