### PR TITLE
Report context switches and runtime version to bridge

### DIFF
--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -19,7 +19,7 @@ from dmoj.utils.ansi import print_ansi
 from dmoj.utils.error import print_protection_fault
 from dmoj.utils.unicode import utf8bytes, utf8text
 
-version_cache: Dict[str, List[Tuple[str, Optional[Tuple[int, ...]]]]] = {}
+version_cache: Dict[str, List[Tuple[str, Tuple[int, ...]]]] = {}
 
 if os.path.isdir('/usr/home'):
     USR_DIR = [RecursiveDir(f'/usr/{d}') for d in os.listdir('/usr') if d != 'home' and os.path.isdir(f'/usr/{d}')]
@@ -341,13 +341,14 @@ class BaseExecutor(metaclass=ExecutorMeta):
                 cls.get_runtime_versions()
                 usage = f'[{proc.execution_time:.3f}s, {proc.max_memory} KB]'
                 print_ansi(f'{["#ansi[Failed](red|bold) ", "#ansi[Success](green|bold)"][res]} {usage:<19}', end=' ')
-
-                runtime_version: List[Tuple[str, str]] = []
-                for runtime, version in cls.get_runtime_versions():
-                    assert version is not None
-                    runtime_version.append((runtime, '.'.join(map(str, version))))
-
-                print_ansi(', '.join(['#ansi[%s](cyan|bold) %s' % v for v in runtime_version]))
+                print_ansi(
+                    ', '.join(
+                        [
+                            f'#ansi[{runtime}](cyan|bold) {".".join(map(str, version))}'
+                            for runtime, version in cls.get_runtime_versions()
+                        ]
+                    )
+                )
             if stdout.strip() != test_message and error_callback:
                 error_callback('Got unexpected stdout output:\n' + utf8text(stdout))
             if stderr:
@@ -374,12 +375,12 @@ class BaseExecutor(metaclass=ExecutorMeta):
         return [(cls.command, command)]
 
     @classmethod
-    def get_runtime_versions(cls) -> List[Tuple[str, Optional[Tuple[int, ...]]]]:
+    def get_runtime_versions(cls) -> List[Tuple[str, Tuple[int, ...]]]:
         key = cls.get_executor_name()
         if key in version_cache:
             return version_cache[key]
 
-        versions: List[Tuple[str, Optional[Tuple[int, ...]]]] = []
+        versions: List[Tuple[str, Tuple[int, ...]]] = []
         for runtime, path in cls.get_versionable_commands():
             flags = cls.get_version_flags(runtime)
 

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -186,6 +186,9 @@ class BaseExecutor(metaclass=ExecutorMeta):
         result.execution_time = process.execution_time or 0.0
         result.wall_clock_time = process.wall_clock_time or 0.0
         result.context_switches = process.context_switches or (0, 0)
+        result.runtime_version = ', '.join(
+            f'{runtime} {".".join(map(str, version))}' for runtime, version in self.get_runtime_versions()
+        )
 
         if process.is_ir:
             result.result_flag |= Result.IR

--- a/dmoj/packet.py
+++ b/dmoj/packet.py
@@ -206,6 +206,9 @@ class PacketManager:
                             'output': result.output,
                             'extended-feedback': result.extended_feedback,
                             'feedback': result.feedback,
+                            'voluntary-context-switches': result.context_switches[0],
+                            'involuntary-context-switches': result.context_switches[1],
+                            'runtime-version': result.runtime_version,
                         }
                         for position, result in self._testcase_queue
                     ],

--- a/dmoj/result.py
+++ b/dmoj/result.py
@@ -34,6 +34,7 @@ class Result:
         wall_clock_time=0,
         max_memory=0,
         context_switches=(0, 0),
+        runtime_version='',
         proc_output='',
         feedback='',
         extended_feedback='',
@@ -44,6 +45,7 @@ class Result:
         self.execution_time = execution_time
         self.wall_clock_time = wall_clock_time
         self.context_switches = context_switches
+        self.runtime_version = runtime_version
         self.max_memory = max_memory
         self.proc_output = proc_output
         self.feedback = feedback


### PR DESCRIPTION
The first commit simplifies the interface of `get_runtime_versions` so that no mypy asserts are needed.