### PR TITLE
remove goto for failing seccomp

### DIFF
--- a/dmoj/cptbox/helper.cpp
+++ b/dmoj/cptbox/helper.cpp
@@ -101,7 +101,7 @@ int cptbox_child_run(const struct child_config *config) {
     scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_TRACE(0));
     if (!ctx) {
         fprintf(stderr, "Failed to initialize seccomp context!");
-        goto seccomp_fail;
+        goto seccomp_init_fail;
     }
 
     int rc;
@@ -132,7 +132,7 @@ int cptbox_child_run(const struct child_config *config) {
 
     if ((rc = seccomp_load(ctx))) {
         fprintf(stderr, "seccomp_load: %s\n", strerror(-rc));
-        goto seccomp_fail;
+        goto seccomp_load_fail;
     }
 
     seccomp_release(ctx);
@@ -166,8 +166,13 @@ int cptbox_child_run(const struct child_config *config) {
     perror("execve");
     return PTBOX_SPAWN_FAIL_EXECVE;
 
-seccomp_fail:
+#if !PTBOX_FREEBSD
+seccomp_init_fail:
+    seccomp_release(ctx);
+
+seccomp_load_fail:
     return PTBOX_SPAWN_FAIL_SECCOMP;
+#endif
 }
 
 // From python's _posixsubprocess


### PR DESCRIPTION
I'm assuming this just wasn't cleaned up at some point. Not a lot of point in having a `goto`, in my opinion it just makes this more confusing.