### PR TITLE
executors: remove .gforth-history

### DIFF
--- a/dmoj/executors/FORTH.py
+++ b/dmoj/executors/FORTH.py
@@ -1,4 +1,3 @@
-from dmoj.cptbox.filesystem_policies import ExactFile
 from dmoj.executors.script_executor import ScriptExecutor
 
 
@@ -10,7 +9,6 @@ class Executor(ScriptExecutor):
 
 HELLO
 """
-    fs = [ExactFile('/.gforth-history')]
 
     def get_cmdline(self, **kwargs):
         return [self.get_command(), self._code, '-e', 'bye']


### PR DESCRIPTION
This path doesn't exist in Docker, so there's no sense in allowing it.