### PR TITLE
judge: rename requirements to dependencies

### DIFF
--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -458,13 +458,13 @@ class JudgeWorker:
 
         flattened_cases: List[Tuple[Optional[int], Union[TestCase, BatchedTestCase]]] = []
         batch_number = 0
-        batch_requirements: List[Set[int]] = []
+        batch_dependencies: List[Set[int]] = []
         for case in self.grader.cases():
             if isinstance(case, BatchedTestCase):
                 batch_number += 1
                 for batched_case in case.batched_cases:
                     flattened_cases.append((batch_number, batched_case))
-                batch_requirements.append(set(case.requirements))
+                batch_dependencies.append(set(case.dependencies))
             else:
                 flattened_cases.append((None, case))
 
@@ -476,8 +476,8 @@ class JudgeWorker:
             if batch_number:
                 yield IPC.BATCH_BEGIN, (batch_number,)
 
-                requirements = batch_requirements[batch_number - 1]  # List is zero-indexed
-                if passed_batches & requirements != requirements:
+                dependencies = batch_dependencies[batch_number - 1]  # List is zero-indexed
+                if passed_batches & dependencies != dependencies:
                     is_short_circuiting = True
 
             for _, case in cases:

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -210,7 +210,7 @@ class ProblemConfig(ConfigNode):
                     'output_limit_length': 25165824,
                     'binary_data': False,
                     'short_circuit': True,
-                    'requirements': [],
+                    'dependencies': [],
                     'points': 1,
                     'symlinks': {},
                     'meta': meta,
@@ -223,15 +223,15 @@ class BatchedTestCase:
         self.config = config
         self.batch_no = batch_no
         self.points = config.points
-        self.requirements = config.requirements
+        self.dependencies = config.dependencies
         self.batched_cases = cases
         if any(isinstance(case, BatchedTestCase) for case in self.batched_cases):
             raise InvalidInitException('nested batches')
         self.problem = problem
-        if any(requirement >= batch_no for requirement in self.requirements):
-            raise InvalidInitException('requirements depends on non-earlier batch')
-        if any(requirement < 1 for requirement in self.requirements):
-            raise InvalidInitException('requirements must be positive integers')
+        if any(dependency >= batch_no for dependency in self.dependencies):
+            raise InvalidInitException('dependencies depends on non-earlier batch')
+        if any(dependency < 1 for dependency in self.dependencies):
+            raise InvalidInitException('dependencies must be positive integers')
 
     def __str__(self):
         return 'BatchedTestCase{cases=%s}' % str(self.batched_cases)

--- a/testsuite/batch_requirements/init.yml
+++ b/testsuite/batch_requirements/init.yml
@@ -8,7 +8,7 @@ test_cases:
 - batched:
   - {in: 3.txt, out: 3.txt}
   points: 1
-  requirements: [1, 2]
+  dependencies: [1, 2]
 - batched:
   - {in: 1.txt, out: 1.txt}
   points: 1


### PR DESCRIPTION
We should do this before anything builds on this. I think `dependencies` is a better name, is more succint, and well-known to programmers.