### PR TITLE
Upgrade black to 22.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: '3.10'
     - name: Install Black and Flake8
       run: |
-        pip install black==21.8b0 flake8 flake8-future-import flake8-logging-format flake8-import-order flake8-quotes flake8-black
+        pip install black==22.3 flake8 flake8-future-import flake8-logging-format flake8-import-order flake8-quotes flake8-black
     - name: Run Flake8
       run: |
         black --version

--- a/dmoj/sysinfo.py
+++ b/dmoj/sysinfo.py
@@ -13,7 +13,6 @@ if hasattr(os, 'getloadavg'):
             load = -1
         return 'load', load
 
-
 else:
     # There exist some Unix platforms (like Android) which don't
     # have `getloadavg` implemented, but aren't Windows

--- a/dmoj/tests/test_int_patch.py
+++ b/dmoj/tests/test_int_patch.py
@@ -53,7 +53,7 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(int('-1'), -1)
         self.assertEqual(int('1337'), 1337)
         self.assertEqual(
-            int('9' * builtin_int_patch.INT_MAX_NUMBER_DIGITS), 10 ** builtin_int_patch.INT_MAX_NUMBER_DIGITS - 1
+            int('9' * builtin_int_patch.INT_MAX_NUMBER_DIGITS), 10**builtin_int_patch.INT_MAX_NUMBER_DIGITS - 1
         )
 
     def test_parse_string_long(self):
@@ -64,5 +64,5 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(int(1), 1)
         self.assertEqual(int(-1337), -1337)
         self.assertEqual(
-            int(10 ** builtin_int_patch.INT_MAX_NUMBER_DIGITS), 10 ** builtin_int_patch.INT_MAX_NUMBER_DIGITS
+            int(10**builtin_int_patch.INT_MAX_NUMBER_DIGITS), 10**builtin_int_patch.INT_MAX_NUMBER_DIGITS
         )

--- a/dmoj/utils/os_ext.py
+++ b/dmoj/utils/os_ext.py
@@ -37,7 +37,6 @@ except ImportError:  # before Python 3.8
                 return s.decode('utf-8')
         return f'Unknown signal {signo}'
 
-
 else:
 
     def strsignal(signo: int) -> str:


### PR DESCRIPTION
This is required to fix compatability with Click 8.1.0. Let's upgrade instead of pinning Click.

See https://github.com/psf/black/pull/2966 and note that all lint jobs fail (see #1021).