### PR TITLE
testsuite: increase TL on java aplusb ac

### DIFF
--- a/testsuite/aplusb/tests/java_ac/test.yml
+++ b/testsuite/aplusb/tests/java_ac/test.yml
@@ -1,5 +1,5 @@
 language: JAVA8
-time: 5
+time: 10
 memory: 65536
 source: aplusb.java
 expect: AC


### PR DESCRIPTION
Slower languages like Java tend to flake in FreeBSD CI.