### PR TITLE
Allow rseq syscall

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -162,6 +162,7 @@ class IsolateTracer(dict):
                 sys_time: ALLOW,
                 sys_prlimit64: self.handle_prlimit,
                 sys_getdents64: ALLOW,
+                sys_rseq: ALLOW,
             }
         )
 


### PR DESCRIPTION
Prevents protection fault for `sys_rseq` on Linux kernel versions >=5.16.