### PR TITLE
Fix Groovy slow execution

### DIFF
--- a/dmoj/executors/GROOVY.py
+++ b/dmoj/executors/GROOVY.py
@@ -23,7 +23,7 @@ println System.in.newReader().readLine()
     def get_cmdline(self, **kwargs):
         res = super().get_cmdline(**kwargs)
 
-        res[-2:-1] = ['-Dsubmission.file=%s' % self._class_name] + self.runtime_dict['groovy_args']
+        res[-2:-1] = self.runtime_dict['groovy_args']
         return res
 
     def get_compile_args(self):
@@ -50,7 +50,7 @@ println System.in.newReader().readLine()
         with open(os.devnull, 'w') as devnull:
             process = subprocess.Popen(['bash', '-x', groovy, '-version'], stdout=devnull, stderr=subprocess.PIPE)
         output = utf8text(process.communicate()[1])
-        log = [i for i in output.split('\n') if 'org.codehaus.groovy.tools.GroovyStarter' in i]
+        log = [i for i in output.split('\n') if 'org.codehaus.groovy.tools.GroovyStarter' in i and '-classpath' in i]
 
         if not log:
             return result, False, 'Failed to parse: %s' % groovy
@@ -58,7 +58,8 @@ println System.in.newReader().readLine()
         cmdline = log[-1].lstrip('+ ').split()
 
         result['groovy_vm'] = cls.unravel_java(cls.find_command_from_list([cmdline[1]]))
-        result['groovy_args'] = [i for i in cmdline[2:-1]]
+        i = cmdline.index('-classpath')
+        result['groovy_args'] = ['-classpath', f'.:{cmdline[i + 1]}']
 
         data = cls.autoconfig_run_test(result)
         if data[1]:


### PR DESCRIPTION
Old Groovy:
```
Test case  1 AC [4.978s (5.461s wall) | 115316kb | 12033 switches (4130 involuntary)]
Test case  2 AC [4.824s (5.295s wall) | 107396kb | 12904 switches (4244 involuntary)]
Test case  3 AC [4.670s (5.131s wall) | 129000kb | 12620 switches (4125 involuntary)]
Test case  4 AC [4.772s (5.236s wall) | 123960kb | 12655 switches (4181 involuntary)]
Test case  5 AC [4.714s (5.169s wall) | 115148kb | 12923 switches (4212 involuntary)]
```

New Groovy:
```
Test case  1 AC [1.906s (2.034s wall) | 75136kb | 6548 switches (2030 involuntary)]
Test case  2 AC [1.871s (2.000s wall) | 75324kb | 6753 switches (2072 involuntary)]
Test case  3 AC [1.847s (1.991s wall) | 75700kb | 6816 switches (2107 involuntary)]
Test case  4 AC [1.910s (2.055s wall) | 74756kb | 6547 switches (2034 involuntary)]
Test case  5 AC [1.954s (2.105s wall) | 75264kb | 6650 switches (2034 involuntary)]
```