### PR TITLE
isolate: globally allow `clone3`

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -144,6 +144,7 @@ class IsolateTracer(dict):
                 sys_getppid: ALLOW,
                 sys_sched_yield: ALLOW,
                 sys_clone: ALLOW,
+                sys_clone3: ALLOW,
                 sys_exit: ALLOW,
                 sys_exit_group: ALLOW,
                 sys_gettid: ALLOW,


### PR DESCRIPTION
Java 17 started using it, and we already globally allow `clone`.