### PR TITLE
Make `INT_MAX_NUMBER_DIGITS` backwards compatible

### DIFF
--- a/dmoj/utils/builtin_int_patch.py
+++ b/dmoj/utils/builtin_int_patch.py
@@ -2,7 +2,7 @@
 import sys
 
 # Drop to Python's limit, see https://github.com/python/cpython/issues/95778
-INT_MAX_NUMBER_DIGITS = sys.int_info.default_max_str_digits
+INT_MAX_NUMBER_DIGITS = getattr(sys.int_info, 'default_max_str_digits', 4300)
 int_ = int
 
 if isinstance(__builtins__, dict):


### PR DESCRIPTION
> when you remember we don't run the latest Python in prod