### PR TITLE
executors/RUST: update package versions

### DIFF
--- a/dmoj/executors/RUST.py
+++ b/dmoj/executors/RUST.py
@@ -11,7 +11,9 @@ version = "1.0.0"
 
 [dependencies]
 dmoj = "0.1"
-rand = "0.3"
+libc = "0.2"
+rand = "0.8"
+rand_xoshiro = "0.6"
 
 [profile.release]
 strip = "symbols"


### PR DESCRIPTION
This will definitely fail in CI. The reason is that [this file](https://github.com/DMOJ/runtimes-docker/blob/master/tier2/Dockerfile#L26-L29) is responsible for the fetching of RUST packages. Since it always fetches from master, only when this PR is merged can CI pass.

To make sure it will pass, I tested locally with:

```
cp ~/Projects/dmoj/judge/judge-server/dmoj/executors/RUST.py . && sed '/^CARGO_TOML/,/^"""/!d;//d' RUST.py > Cargo.toml && sed '/^CARGO_LOCK/,/^"""/!d;//d' RUST.py > Cargo.lock && mkdir -p src && sed '/^HELLO_WORLD_PROGRAM/,/^"""/!d;//d' RUST.py > src/main.rs && cargo fetch
```

Essentially, I do the same thing as the Dockerfile does, fetch the new packages, and then run cargo offline, like it is in Docker:

```
DMOJ_CARGO_OFFLINE=y python3 .docker.test.py
```

This worked for me, so I believe this PR should pass when merged.

I didn't upgrade `lazy_static` because it is a dependency of the [dmoj-rust](https://github.com/DMOJ/dmoj-rust/blob/master/Cargo.toml) package, and as such shouldn't be changed. It could be upgraded to `0.2.11`, since that has compatibility according to [the manifest spec](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio), but that seems pointless. `libc` and `rand` are the actual important packages. `libc`'s upgrade should cause no incompatibility, and `rand` is so outdated that it's practically unusable these days.

## Breaking Changes

Any rust subs using `rand` are likely to break if rejudged, but there's not a whole lot to be done here...

