### PR TITLE
Rust allow libc

### DIFF
--- a/dmoj/executors/RUST.py
+++ b/dmoj/executors/RUST.py
@@ -11,7 +11,7 @@ version = "1.0.0"
 
 [dependencies]
 dmoj = "0.1"
-rand = "0.3"
+rand = "0.8"
 """
 
 CARGO_LOCK = b"""\
@@ -22,7 +22,7 @@ name = "user_submission"
 version = "1.0.0"
 dependencies = [
  "dmoj 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [profile.release]
@@ -34,7 +34,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.135 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -44,12 +44,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.18"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.15"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -58,8 +58,8 @@ dependencies = [
 [metadata]
 "checksum dmoj 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a1f8a155771d562ab98db35ed9b4da482ef178eec293eeb1f6302036100e84f1"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
-"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
-"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum libc 0.2.135 (registry+https://github.com/rust-lang/crates.io-index)" = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+"checksum rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 """  # noqa: E501
 
 HELLO_WORLD_PROGRAM = """\

--- a/dmoj/executors/RUST.py
+++ b/dmoj/executors/RUST.py
@@ -11,6 +11,7 @@ version = "1.0.0"
 
 [dependencies]
 dmoj = "0.1"
+libc = "0.2"
 rand = "0.8"
 """
 


### PR DESCRIPTION
Based on #1062.

Allow `libc` in user submissions. One clear use case of this is that in interactive problems, it is desirable to close `stdout` to signal to the interactor that interaction is over (or as the interactor, to signal the same thing). Rust obviously won't let us do this without unsafe code, but without `libc`, it's not even possible.

This signalling is useful because, for instance, validators want to ensure that the interactor doesn't output anything strange after `stdout` is closed, but it's more useful for interactors to make sure that the user doesn't output anything else after the answer is received (which, under a strict definition, should result in a WA verdict).