### PR TITLE
.NET 6 support

### DIFF
--- a/dmoj/executors/NETCS.py
+++ b/dmoj/executors/NETCS.py
@@ -19,6 +19,7 @@ HELLO_WORLD_PROGRAM = """\
 Console.WriteLine("Hello, World!");
 """
 
+
 class Executor(CompiledExecutor):
     ext = 'cs'
     command = 'dotnet'
@@ -36,10 +37,6 @@ class Executor(CompiledExecutor):
 
         with open(self._file('DMOJ.csproj'), 'wb') as f:
             f.write(CSPROJ)
-
-    @classmethod
-    def get_versionable_commands(cls):
-        return [('dotnet', os.path.join(os.path.dirname(cls.get_command()), 'dotnet'))]
 
     def get_compile_args(self):
         return [self.get_command(), 'publish', '--configuration', 'release', '--self-contained', 'false']

--- a/dmoj/executors/NETCS.py
+++ b/dmoj/executors/NETCS.py
@@ -1,0 +1,48 @@
+import os
+
+from dmoj.cptbox.filesystem_policies import ExactFile, RecursiveDir
+from dmoj.executors.compiled_executor import CompiledExecutor
+
+CSPROJ = b"""\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishSingleFile>true</PublishSingleFile>
+  </PropertyGroup>
+</Project>
+"""
+
+HELLO_WORLD_PROGRAM = """\
+Console.WriteLine("Hello, World!");
+"""
+
+class Executor(CompiledExecutor):
+    ext = 'cs'
+    command = 'dotnet'
+    test_program = HELLO_WORLD_PROGRAM
+    compiler_time_limit = 20
+    compiler_write_fs = [
+        RecursiveDir('~/.nuget/packages'),
+        RecursiveDir('~/.local/share/NuGet'),
+        RecursiveDir('/tmp/NuGetScratch'),
+    ]
+
+    def create_files(self, problem_id, source_code, *args, **kwargs):
+        with open(self._file('Program.cs'), 'wb') as f:
+            f.write(source_code)
+
+        with open(self._file('DMOJ.csproj'), 'wb') as f:
+            f.write(CSPROJ)
+
+    @classmethod
+    def get_versionable_commands(cls):
+        return [('dotnet', os.path.join(os.path.dirname(cls.get_command()), 'dotnet'))]
+
+    def get_compile_args(self):
+        return [self.get_command(), 'publish', '--configuration', 'release', '--self-contained', 'false']
+
+    def get_compiled_file(self):
+        return self._file('bin', 'release', 'net6.0', 'DMOJ.exe')


### PR DESCRIPTION
relates to https://github.com/DMOJ/judge-server/issues/1060
requires .NET 6 available on the runtimes image: https://github.com/DMOJ/runtimes-docker/pull/40

A first attempt at adding .NET 6 support. This is what I cobbled together based on the some other executor implementations.

Given my lack of detailed understanding of the judge server and python, there are most likely issues with the implementation. Still, it is somewhat complicated to test the behavior locally (especially without the updated runtime image). I'd appreciate some help/guidance on how to test the implementation locally/on docker.