### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install Black and Flake8
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install dependencies and mypy
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install build dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
@@ -26,7 +26,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
@@ -42,7 +42,7 @@ jobs:
   test-sdist:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
@@ -63,7 +63,7 @@ jobs:
       matrix:
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download docker image
         run: docker pull dmoj/runtimes-tier3
       - name: Install python
@@ -119,7 +119,7 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download docker image
         run: docker pull dmoj/runtimes-tier3
       - name: Create docker scripts

--- a/.github/workflows/update-syscalls.yml
+++ b/.github/workflows/update-syscalls.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.repository == 'DMOJ/judge-server'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/update-syscalls.yml
+++ b/.github/workflows/update-syscalls.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.7'
     - name: Update syscalls
       run: |
         cd dmoj/cptbox/syscalls

--- a/.github/workflows/update-syscalls.yml
+++ b/.github/workflows/update-syscalls.yml
@@ -17,7 +17,7 @@ jobs:
         cd dmoj/cptbox/syscalls
         python generate.py
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.REPO_SCOPED_TOKEN }}
         author: dmoj-build <build@dmoj.ca>

--- a/.github/workflows/upload-pypi.yml
+++ b/.github/workflows/upload-pypi.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/upload-pypi.yml
+++ b/.github/workflows/upload-pypi.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.9'
       - name: Install build dependencies
         run: pip install cython
       - name: Create sdist


### PR DESCRIPTION
Resolving:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, peter-evans/create-pull-request, actions/checkout
