### PR TITLE
Fix bug where `get_supported_problems_and_mtimes` won't recursively scan

### DIFF
--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -353,7 +353,7 @@ def get_supported_problems_and_mtimes():
     problems = []
     if problem_globs:
         for dir_glob in problem_globs:
-            for problem_config in glob.iglob(os.path.join(dir_glob, 'init.yml')):
+            for problem_config in glob.iglob(os.path.join(dir_glob, 'init.yml'), recursive=True):
                 if os.access(problem_config, os.R_OK):
                     problem_dir = os.path.dirname(problem_config)
                     problem = utf8text(os.path.basename(problem_dir))

--- a/dmoj/tests/test_globs.py
+++ b/dmoj/tests/test_globs.py
@@ -55,6 +55,8 @@ class TestConfigGlobs(unittest.TestCase):
             )
         )
 
+        self.supported_problems = ['p1', 'p1', 'p4', 'p5', 'p6']
+
         problem_globs = list(
             map(
                 str,
@@ -88,6 +90,11 @@ class TestConfigGlobs(unittest.TestCase):
 
             for problem in ex_cases:
                 self.assertRaises(KeyError, judgeenv.get_problem_root, problem)
+
+    def test_supported_problems(self):
+        with self.mock_problem_roots:
+            supported_problems = judgeenv.get_supported_problems()
+            self.assertEqual(list(sorted(self.supported_problems)), list(sorted(supported_problems)))
 
     def tearDown(self):
         self.root.cleanup()


### PR DESCRIPTION
Also added a test.

Additional question: should we return a problem multiple times if it has different locations?