### PR TITLE
Declare types for `Result` and `CheckerResult`

### DIFF
--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -182,7 +182,7 @@ class BaseExecutor(metaclass=ExecutorMeta):
 
     def populate_result(self, stderr: bytes, result: Result, process: TracedPopen) -> None:
         # Translate status codes/process results into Result object for status codes
-        result.max_memory = process.max_memory or 0.0
+        result.max_memory = process.max_memory or 0
         result.execution_time = process.execution_time or 0.0
         result.wall_clock_time = process.wall_clock_time or 0.0
         result.context_switches = process.context_switches or (0, 0)

--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -511,7 +511,7 @@ class JudgeWorker:
                 # Legacy hack: we need to allow graders to read and write `proc_output` on the `Result` object, but the
                 # judge controller only cares about the trimmed output, and shouldn't waste memory buffering the full
                 # output. So, we trim it here so we don't run out of memory in the controller.
-                result.proc_output = result.output
+                result.proc_output = utf8bytes(result.output)
                 yield IPC.RESULT, (batch_number, case_number, result)
 
             if batch_number:

--- a/dmoj/result.py
+++ b/dmoj/result.py
@@ -1,6 +1,13 @@
+from typing import List, Optional, TYPE_CHECKING, Tuple
+
 from dmoj.utils.error import print_protection_fault
 from dmoj.utils.os_ext import strsignal
 from dmoj.utils.unicode import utf8text
+
+if TYPE_CHECKING:
+    from dmoj.cptbox import TracedPopen
+    from dmoj.executors.base_executor import BaseExecutor
+    from dmoj.problem import TestCase
 
 
 class Result:
@@ -28,38 +35,38 @@ class Result:
 
     def __init__(
         self,
-        case,
-        result_flag=0,
-        execution_time=0,
-        wall_clock_time=0,
-        max_memory=0,
-        context_switches=(0, 0),
-        runtime_version='',
-        proc_output='',
-        feedback='',
-        extended_feedback='',
-        points=0,
+        case: 'TestCase',
+        result_flag: int = 0,
+        execution_time: float = 0,
+        wall_clock_time: float = 0,
+        max_memory: int = 0,
+        context_switches: Tuple[int, int] = (0, 0),
+        runtime_version: str = '',
+        proc_output: bytes = b'',
+        feedback: str = '',
+        extended_feedback: str = '',
+        points: float = 0,
     ):
-        self.case = case
-        self.result_flag = result_flag
-        self.execution_time = execution_time
-        self.wall_clock_time = wall_clock_time
-        self.context_switches = context_switches
-        self.runtime_version = runtime_version
-        self.max_memory = max_memory
-        self.proc_output = proc_output
-        self.feedback = feedback
-        self.extended_feedback = extended_feedback
-        self.points = points
+        self.case: 'TestCase' = case
+        self.result_flag: int = result_flag
+        self.execution_time: float = execution_time
+        self.wall_clock_time: float = wall_clock_time
+        self.context_switches: Tuple[int, int] = context_switches
+        self.runtime_version: str = runtime_version
+        self.max_memory: int = max_memory
+        self.proc_output: bytes = proc_output
+        self.feedback: str = feedback
+        self.extended_feedback: str = extended_feedback
+        self.points: float = points
 
-    def get_main_code(self):
+    def get_main_code(self) -> int:
         for flag in Result.CODE_DISPLAY_ORDER:
             code = getattr(Result, flag)
             if self.result_flag & code:
                 return code
         return Result.AC
 
-    def readable_codes(self):
+    def readable_codes(self) -> List[str]:
         execution_verdict = []
         for flag in Result.CODE_DISPLAY_ORDER:
             if self.result_flag & getattr(Result, flag):
@@ -67,18 +74,18 @@ class Result:
         return execution_verdict or ['AC']
 
     @property
-    def total_points(self):
+    def total_points(self) -> float:
         return self.case.points
 
     @property
-    def output(self):
+    def output(self) -> str:
         return utf8text(self.proc_output[: self.case.output_prefix_length], 'replace')
 
     @classmethod
-    def get_feedback_str(cls, error, process, binary):
+    def get_feedback_str(cls, error: bytes, process: 'TracedPopen', binary: 'BaseExecutor') -> str:
         is_ir_or_rte = (process.is_ir or process.is_rte) and not (process.is_tle or process.is_mle or process.is_ole)
         if hasattr(process, 'feedback'):
-            feedback = process.feedback
+            feedback = utf8text(process.feedback)
         elif is_ir_or_rte:
             feedback = binary.parse_feedback_from_stderr(error, process)
         else:
@@ -96,24 +103,28 @@ class Result:
             syscall, callname, args, update_errno = process.protection_fault
             print_protection_fault(process.protection_fault)
             callname = callname.replace('sys_', '', 1)
-            message = '%s syscall disallowed' % callname
+            message = f'{callname} syscall disallowed'
             feedback = message
 
         return feedback
 
-    def update_feedback(self, error, process, binary, feedback=None):
+    def update_feedback(
+        self, error: bytes, process: 'TracedPopen', binary: 'BaseExecutor', feedback: Optional[str] = None
+    ) -> None:
         self.feedback = feedback or self.get_feedback_str(error, process, binary)
 
 
 class CheckerResult:
-    def __init__(self, passed, points, feedback=None, extended_feedback=None):
+    def __init__(
+        self, passed: bool, points: float, feedback: Optional[str] = None, extended_feedback: Optional[str] = None
+    ):
         # Make sure we don't kill the site bridge
         assert isinstance(passed, bool)
         assert isinstance(points, int) or isinstance(points, float)
         assert feedback is None or isinstance(feedback, str)
         assert extended_feedback is None or isinstance(extended_feedback, str)
 
-        self.passed = passed
-        self.points = points
-        self.feedback = feedback
-        self.extended_feedback = extended_feedback
+        self.passed: bool = passed
+        self.points: float = points
+        self.feedback: Optional[str] = feedback
+        self.extended_feedback: Optional[str] = extended_feedback

--- a/testsuite/seed2/tests/java_ir/seed2.java
+++ b/testsuite/seed2/tests/java_ir/seed2.java
@@ -1,0 +1,6 @@
+public class Seed2 {
+    public static void main(String[] args) {
+      int[] arr = new int[1];
+      arr[1] = 1;
+    }
+}

--- a/testsuite/seed2/tests/java_ir/test.yml
+++ b/testsuite/seed2/tests/java_ir/test.yml
@@ -1,0 +1,6 @@
+language: JAVA8
+time: 2
+memory: 65536
+source: seed2.java
+expect: IR
+feedback: java.lang.ArrayIndexOutOfBoundsException

--- a/testsuite/seed2/tests/java_mle/seed2.java
+++ b/testsuite/seed2/tests/java_mle/seed2.java
@@ -1,0 +1,23 @@
+import java.util.*;
+
+public class Seed2 {
+    public static void main(String[] args) {
+        int[] arr = new int[1000000000];
+        Scanner sc = new Scanner(System.in);
+        String result;
+        long lo = 1;
+        long hi = 2000000000;
+        long num;
+        while (lo < hi) {
+            num = (lo + hi) / 2;
+            System.out.println(num);
+            result = sc.nextLine();
+            if (result.equals("FLOATS"))
+                hi = num;
+            else if (result.equals("SINKS"))
+                lo = num + 1;
+            else
+                break;
+        }
+    }
+}

--- a/testsuite/seed2/tests/java_mle/test.yml
+++ b/testsuite/seed2/tests/java_mle/test.yml
@@ -1,0 +1,5 @@
+language: JAVA8
+time: 2
+memory: 65536
+source: seed2.java
+expect: MLE


### PR DESCRIPTION
Fixes a bug where interactive problems will crash upon grading a Java submission that returns `IR` due to `result.proc_output` being the empty string `''` by default. `result.proc_output` should now always be a bytestring.