### PR TITLE
Detect JVM initialization errors

### DIFF
--- a/testsuite/bridged_interactor/tests/java8_grace/seed2.java
+++ b/testsuite/bridged_interactor/tests/java8_grace/seed2.java
@@ -1,0 +1,22 @@
+import java.util.*;
+
+public class Seed2 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        String result;
+        long lo = 1;
+        long hi = 2000000000;
+        long num;
+        while (lo < hi) {
+            num = (lo + hi) / 2;
+            System.out.println(num);
+            result = sc.nextLine();
+            if (result.equals("FLOATS"))
+                hi = num;
+            else if (result.equals("SINKS"))
+                lo = num + 1;
+            else
+                break;
+        }
+    }
+}

--- a/testsuite/bridged_interactor/tests/java8_grace/test.yml
+++ b/testsuite/bridged_interactor/tests/java8_grace/test.yml
@@ -1,0 +1,5 @@
+language: JAVA8
+time: 2
+memory: 1
+source: seed2.java
+expect: MLE

--- a/testsuite/helloworld/tests/java8_grace/grace.java
+++ b/testsuite/helloworld/tests/java8_grace/grace.java
@@ -1,0 +1,5 @@
+public class grace {
+  public static void main(String[] args) {
+    System.out.println("Hello, World!");
+  }
+}

--- a/testsuite/helloworld/tests/java8_grace/test.yml
+++ b/testsuite/helloworld/tests/java8_grace/test.yml
@@ -1,0 +1,5 @@
+language: JAVA8
+time: 2
+memory: 1
+source: grace.java
+expect: MLE

--- a/testsuite/seed2/tests/java8_grace/seed2.java
+++ b/testsuite/seed2/tests/java8_grace/seed2.java
@@ -1,0 +1,22 @@
+import java.util.*;
+
+public class Seed2 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        String result;
+        long lo = 1;
+        long hi = 2000000000;
+        long num;
+        while (lo < hi) {
+            num = (lo + hi) / 2;
+            System.out.println(num);
+            result = sc.nextLine();
+            if (result.equals("FLOATS"))
+                hi = num;
+            else if (result.equals("SINKS"))
+                lo = num + 1;
+            else
+                break;
+        }
+    }
+}

--- a/testsuite/seed2/tests/java8_grace/test.yml
+++ b/testsuite/seed2/tests/java8_grace/test.yml
@@ -1,0 +1,5 @@
+language: JAVA8
+time: 2
+memory: 1
+source: seed2.java
+expect: MLE

--- a/testsuite/seed2/tests/java_grace/seed2.java
+++ b/testsuite/seed2/tests/java_grace/seed2.java
@@ -1,0 +1,22 @@
+import java.util.*;
+
+public class Seed2 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        String result;
+        long lo = 1;
+        long hi = 2000000000;
+        long num;
+        while (lo < hi) {
+            num = (lo + hi) / 2;
+            System.out.println(num);
+            result = sc.nextLine();
+            if (result.equals("FLOATS"))
+                hi = num;
+            else if (result.equals("SINKS"))
+                lo = num + 1;
+            else
+                break;
+        }
+    }
+}

--- a/testsuite/seed2/tests/java_grace/test.yml
+++ b/testsuite/seed2/tests/java_grace/test.yml
@@ -1,0 +1,5 @@
+language: JAVA
+time: 2
+memory: 1
+source: seed2.java
+expect: MLE


### PR DESCRIPTION
Changes:
1. print error to `stderr` instead of `stdout`, so we can detect this error within interactive graders
2. add more test cases, because JAVA8 has a slightly different error message, and there is a unique message at 2MB because god is dead and Java killed them