### PR TITLE
Exec final command of docker entry file

### DIFF
--- a/.docker/entry
+++ b/.docker/entry
@@ -20,4 +20,4 @@ esac
 
 shift
 . ~judge/.profile
-runuser -u judge "${command[@]}" -- "$@"
+exec runuser -u judge "${command[@]}" -- "$@"


### PR DESCRIPTION
This makes `docker stop` graceful, since otherwise, `bash` receives SIGTERM, and ignores it. With this setup, `runuser` receives SIGTERM.