### PR TITLE
Support passing judge credentials through environment

### DIFF
--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -186,9 +186,13 @@ def load_env(cli=False, testsuite=False):  # pragma: no cover
 
     if getattr(args, 'judge_name', None):
         env['id'] = args.judge_name
+    elif 'DMOJ_JUDGE_NAME' in os.environ:
+        env['id'] = os.environ['DMOJ_JUDGE_NAME']
 
     if getattr(args, 'judge_key', None):
         env['key'] = args.judge_key
+    elif 'DMOJ_JUDGE_KEY' in os.environ:
+        env['key'] = os.environ['DMOJ_JUDGE_KEY']
 
     if env.problem_storage_globs:
         problem_globs = env.problem_storage_globs


### PR DESCRIPTION
The following environment variables may be used to define judge credentials, which are override by the command line arguments:

* `DMOJ_JUDGE_NAME`: for the judge name
* `DMOJ_JUDGE_KEY`: for the judge secret key