### PR TITLE
Add `locate` command

### DIFF
--- a/dmoj/commands/__init__.py
+++ b/dmoj/commands/__init__.py
@@ -3,6 +3,7 @@ from typing import List, Type
 from dmoj.commands.base_command import Command, commands, register_command
 from dmoj.commands.diff import DifferenceCommand
 from dmoj.commands.help import HelpCommand
+from dmoj.commands.locate import LocateCommand
 from dmoj.commands.problems import ListProblemsCommand
 from dmoj.commands.quit import QuitCommand
 from dmoj.commands.rejudge import RejudgeCommand
@@ -21,6 +22,7 @@ all_commands: List[Type[Command]] = [
     DifferenceCommand,
     TestCommand,
     ShowCommand,
+    LocateCommand,
     HelpCommand,
     QuitCommand,
 ]

--- a/dmoj/commands/locate.py
+++ b/dmoj/commands/locate.py
@@ -1,0 +1,23 @@
+import sys
+
+from dmoj import judgeenv
+from dmoj.commands.base_command import Command
+
+
+class LocateCommand(Command):
+    name = 'locate'
+    help = 'Locates the folders for problems available to be graded on this judge.'
+
+    def _populate_parser(self) -> None:
+        self.arg_parser.add_argument('problems', nargs='+', help='problems to locate')
+
+    def execute(self, line: str) -> None:
+        args = self.arg_parser.parse_args(line)
+
+        problems = args.problems
+        for problem in problems:
+            root = judgeenv.get_problem_root(problem)
+            if root is None:
+                print(f'{problem} is not a valid problem, skipping', file=sys.stderr)
+            else:
+                print(root)

--- a/dmoj/commands/resubmit.py
+++ b/dmoj/commands/resubmit.py
@@ -32,7 +32,7 @@ class ResubmitCommand(Command):
         tl = args.time_limit or tl
         ml = args.memory_limit or ml
 
-        if id not in judgeenv.get_supported_problems():
+        if problem_id not in judgeenv.get_supported_problems():
             raise InvalidCommandException(f"unknown problem '{problem_id}'")
         elif lang not in executors:
             raise InvalidCommandException(f"unknown language '{lang}'")

--- a/dmoj/packet.py
+++ b/dmoj/packet.py
@@ -299,7 +299,7 @@ class PacketManager:
                 log.error('Handshake failed.')
                 raise JudgeAuthenticationFailed()
 
-    def supported_problems_packet(self, problems: List[Tuple[str, int]]):
+    def supported_problems_packet(self, problems: List[Tuple[str, float]]):
         log.debug('Update problems')
         self._send_packet({'name': 'supported-problems', 'problems': problems})
 

--- a/dmoj/tests/test_globs.py
+++ b/dmoj/tests/test_globs.py
@@ -89,7 +89,7 @@ class TestConfigGlobs(unittest.TestCase):
             ex_cases = ['p2', 'p3', 'doesnotexist']
 
             for problem in ex_cases:
-                self.assertRaises(KeyError, judgeenv.get_problem_root, problem)
+                self.assertIsNone(judgeenv.get_problem_root(problem))
 
     def test_supported_problems(self):
         with self.mock_problem_roots:


### PR DESCRIPTION
* Add `locate` command: output is
```
Skipped self-tests

Running local judge...

/tmp/problems/a
/tmp/problems/b
c is not a valid problem, skipping
```
for file structure
```
/tmp/problems » tree
.
├── a
│   └── init.yml
└── b
    └── init.yml

3 directories, 2 files
```
* Add typing annotations to `dmoj/judgeenv.py`
* Make `get_problem_root` return `None` if the problem does not exist
* Fix typo exposed in `dmoj/commands/resubmit.py` exposed by typing `dmoj/judgeenv.py`
* Fix typing annotation in `dmoj/packet.py`: `os.path.getmtime()` returns a `float` not `int`.