### PR TITLE
 Make _cptbox.pyx compile on Cython 3.x 

### DIFF
--- a/dmoj/cptbox/_cptbox.pyx
+++ b/dmoj/cptbox/_cptbox.pyx
@@ -152,6 +152,9 @@ cdef int pt_child(void *context) noexcept nogil:
 
 cdef int pt_syscall_handler(void *context, int syscall) noexcept nogil:
     return (<Process>context)._syscall_handler(syscall)
+    # Note that upon exception, this function is guaranteed to return due to noexcept.
+    # Cython will swallow any exception raised and print to stderr, then make this function return 0,
+    # which means to deny syscall.
 
 cdef void pt_syscall_return_handler(void *context, pid_t pid, int syscall) noexcept with gil:
     (<Debugger>context)._on_return(pid, syscall)

--- a/dmoj/cptbox/_cptbox.pyx
+++ b/dmoj/cptbox/_cptbox.pyx
@@ -146,17 +146,17 @@ cdef extern from "errno.h":
 
 MAX_SYSCALL_NUMBER = MAX_SYSCALL
 
-cdef int pt_child(void *context) nogil:
+cdef int pt_child(void *context) noexcept nogil:
     cdef child_config *config = <child_config*> context
     return cptbox_child_run(config)
 
-cdef int pt_syscall_handler(void *context, int syscall) nogil:
+cdef int pt_syscall_handler(void *context, int syscall) noexcept nogil:
     return (<Process>context)._syscall_handler(syscall)
 
-cdef void pt_syscall_return_handler(void *context, pid_t pid, int syscall) with gil:
+cdef void pt_syscall_return_handler(void *context, pid_t pid, int syscall) noexcept with gil:
     (<Debugger>context)._on_return(pid, syscall)
 
-cdef int pt_event_handler(void *context, int event, unsigned long param) nogil:
+cdef int pt_event_handler(void *context, int event, unsigned long param) noexcept nogil:
     return (<Process>context)._event_handler(event, param)
 
 cdef char **alloc_byte_array(list list) except NULL:


### PR DESCRIPTION
On Cython 3.x, function signatures are by default `noexcept` and functions not declared `noexcept` can't be assigned to them. This
commit marks functions as `noexcept` so that they compile.

Also document `pt_syscall_handler` exception behaviour.

Fixes #1134.