### PR TITLE
Add Node.js executor for DMOJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The judge can also grade in the languages listed below:
 * Groovy
 * Haskell
 * INTERCAL
+* JavaScript (Node.js and V8)
 * Kotlin
 * Lean 4
 * LLVM IR

--- a/dmoj/executors/NODEJS.py
+++ b/dmoj/executors/NODEJS.py
@@ -1,0 +1,32 @@
+from dmoj.cptbox.filesystem_policies import ExactFile
+from dmoj.executors.script_executor import ScriptExecutor
+
+
+class Executor(ScriptExecutor):
+    ext = 'js'
+    command = 'node'
+    nproc = -1
+    command_paths = ['node', 'nodejs']
+    syscalls = ['capget', 'eventfd2', 'shutdown', 'pkey_alloc']
+    address_grace = 1048576
+    test_program = """
+process.stdin.on('readable', () => {
+    const chunk = process.stdin.read();
+    if (chunk != null) {
+        process.stdout.write(chunk);
+    }
+});
+"""
+
+    def get_env(self):
+        env = super().get_env()
+        # Disable io_uring due to potential security implications
+        env['UV_USE_IO_URING'] = '0'
+        return env
+
+    def get_fs(self):
+        return super().get_fs() + [ExactFile('/usr/lib/ssl/openssl.cnf')]
+
+    @classmethod
+    def get_version_flags(cls, command):
+        return ['--version']


### PR DESCRIPTION
Thanks again for maintaining DMOJ! It's a great project with a really solid security foundation.

### Motivation

We wanted to use DMOJ for internal company events, and since our company's primary language is Javascript (using Node.js), we wanted to implement a version that used Node directly rather than using https://github.com/DMOJ/v8dmoj

This resolves issue https://github.com/DMOJ/judge-server/issues/1136

### Changes

- Add a judge executor that will execute code written in Node.js
  - This was based on the Coffeescript executor, except with some newer syscalls added (e.g., io_uring)

#### Related PRs on other repositories

- https://github.com/DMOJ/runtimes-docker/pull/71: Update Dockerfile to install Node.js to tier3 runtime image

### Testing

Deployed a judge server with this with the following Dockerfile:

```sh
FROM dmoj/runtimes-tier3

# Install Node from nodesource based on https://github.com/nodesource/distributions/tree/69a4558#installation-instructions
RUN apt-get install -y ca-certificates curl gnupg && mkdir -p /etc/apt/keyrings && { curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; } && { echo 'deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main' > /etc/apt/sources.list.d/nodesource.list; } && apt-get update && apt-get install -y nodejs

# The remainder of this file is copied from
# https://github.com/DMOJ/judge-server/blob/master/.docker/tier3/Dockerfile
RUN mkdir /judge /problems && cd /judge && \
	curl -L https://github.com/wanderlog/judge-server/archive/master.tar.gz | tar -xz --strip-components=1 && \
    python3 -m venv --prompt=DMOJ /env && \
	/env/bin/pip3 install cython && \
	/env/bin/pip3 install -e . && \
	/env/bin/python3 setup.py develop && \
	HOME=~judge . ~judge/.profile && \
	runuser -u judge -w PATH -- /env/bin/dmoj-autoconf -V > /judge-runtime-paths.yml && \
	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml
```

Verified that test runs using this Dockerfile worked properly:

![Screen capture](https://github.com/DMOJ/judge-server/assets/2924388/053252d5-b0ee-48d4-8b1d-e46957e43b31)