### PR TITLE
executors/OBJC: fix executor

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -396,9 +396,17 @@ class IsolateTracer(dict):
         PR_GET_DUMPABLE = 3
         PR_SET_NAME = 15
         PR_GET_NAME = 16
+        PR_CAPBSET_READ = 23
         PR_SET_THP_DISABLE = 41
         PR_SET_VMA = 0x53564D41  # Used on Android
-        if debugger.arg0 not in (PR_GET_DUMPABLE, PR_SET_NAME, PR_GET_NAME, PR_SET_THP_DISABLE, PR_SET_VMA):
+        if debugger.arg0 not in (
+            PR_GET_DUMPABLE,
+            PR_SET_NAME,
+            PR_GET_NAME,
+            PR_CAPBSET_READ,
+            PR_SET_THP_DISABLE,
+            PR_SET_VMA,
+        ):
             raise DeniedSyscall(protection_fault, f'Non-whitelisted prctl option: {debugger.arg0}')
 
     # ignore typing because of overload checks

--- a/dmoj/executors/OBJC.py
+++ b/dmoj/executors/OBJC.py
@@ -1,19 +1,17 @@
-import os
 from subprocess import CalledProcessError, check_output
 from typing import List
 
-from dmoj.cptbox.filesystem_policies import ExactFile, FilesystemAccessRule
+from dmoj.cptbox.filesystem_policies import ExactFile, FilesystemAccessRule, RecursiveDir
+from dmoj.executors.base_executor import AutoConfigOutput, AutoConfigResult
 from dmoj.executors.c_like_executor import CLikeExecutor, GCCMixin
-from dmoj.judgeenv import env
 from dmoj.utils.unicode import utf8text
 
 
 class Executor(GCCMixin, CLikeExecutor):
     ext = 'm'
-    objc_flags: List[str] = []
-    objc_ldflags: List[str] = []
-    command = 'gobjc'
+    command = 'gcc'
     address_grace = 131072
+    compiler_read_fs: List[FilesystemAccessRule] = [RecursiveDir('~')]
 
     test_program = r"""
 #import <Foundation/Foundation.h>
@@ -29,21 +27,38 @@ int main (int argc, const char * argv[]) {
 """
 
     def get_flags(self) -> List[str]:
-        return self.objc_flags + super().get_flags()
+        return self.runtime_dict['objc_flags'] + super().get_flags()
 
     def get_ldflags(self) -> List[str]:
-        return self.objc_ldflags + super().get_ldflags()
+        return self.runtime_dict['objc_ldflags'] + super().get_ldflags()
 
     def get_fs(self) -> List[FilesystemAccessRule]:
         return super().get_fs() + [ExactFile('/proc/self/cmdline')]
 
     @classmethod
-    def initialize(cls) -> bool:
-        if 'gnustep-config' not in env['runtime'] or not os.path.isfile(env['runtime']['gnustep-config']):
-            return False
+    def autoconfig(cls) -> AutoConfigOutput:
+        result: AutoConfigResult = {}
+
+        gcc = cls.find_command_from_list(['gcc'])
+        if gcc is None:
+            return result, False, 'Failed to find "gcc"', ''
+        result[cls.command] = gcc
+
+        gnustep_config = cls.find_command_from_list(['gnustep-config'])
+        if gnustep_config is None:
+            return result, False, 'Failed to find "gnustep-config"', ''
+
         try:
-            cls.objc_flags = utf8text(check_output([env['runtime']['gnustep-config'], '--objc-flags'])).split()
-            cls.objc_ldflags = utf8text(check_output([env['runtime']['gnustep-config'], '--base-libs'])).split()
+            result['objc_flags'] = utf8text(check_output([gnustep_config, '--objc-flags'])).split()
         except CalledProcessError:
-            return False
-        return super().initialize()
+            return result, False, 'Failed to run "gnustep-config --objc-flags"', ''
+
+        try:
+            result['objc_ldflags'] = utf8text(check_output([gnustep_config, '--base-libs'])).split()
+        except CalledProcessError:
+            return result, False, 'Failed to run "gnustep-config --base-libs"', ''
+
+        data = cls.autoconfig_run_test(result)
+        if data[1]:
+            data = data[:2] + (f'Using {gcc}',) + data[3:]
+        return data


### PR DESCRIPTION
* This executor calls `prctl` with 23.
* This executor tries to traverse `~/GNUstep`, but this directory doesn't exist. I did `RecursiveDir('~')` to work around this issue.
* Apparently, `initialize(cls)` doesn't run. I wrote `autoconfig(cls)` to do the setup.
* Afterwards, add `apt-get install make gnustep-devel` to the DMOJ dockerfile.