### PR TITLE
Re-enable Dart in CI; refs #1151

### DIFF
--- a/.docker.test.py
+++ b/.docker.test.py
@@ -6,7 +6,7 @@ from dmoj.citest import ci_test
 from dmoj.executors import get_available
 
 arch = platform.machine()
-ALLOW_FAIL = {'DART', 'GASARM', 'OBJC'}
+ALLOW_FAIL = {'GASARM', 'OBJC'}
 EXECUTORS = get_available()
 
 if arch == 'aarch64':


### PR DESCRIPTION
Reverts e2b6533bda8e4a2316de21a3d9551b6e27a5e3d3 as Dart was fixed in 76e86f35ef916091631268f2778d865a0ecb3fa3.