### PR TITLE
Run initialize in CI tests

### DIFF
--- a/dmoj/citest.py
+++ b/dmoj/citest.py
@@ -1,13 +1,12 @@
 import glob
 import os
 import traceback
-from importlib import import_module
 
 import yaml
 
 from dmoj import judgeenv
 from dmoj.contrib import load_contrib_modules
-from dmoj.executors import executors
+from dmoj.executors import executors, load_executor, load_executors
 from dmoj.testsuite import Tester
 from dmoj.utils.ansi import print_ansi
 
@@ -17,8 +16,10 @@ def ci_test(executors_to_test, overrides, allow_fail=frozenset()):
     failed = False
     failed_executors = []
 
+    load_executors()
+
     for name in executors_to_test:
-        executor = import_module('dmoj.executors.' + name)
+        executor = load_executor(name)
 
         print_ansi('%-34s%s' % ('Testing #ansi[%s](|underline):' % name, ''), end=' ')
 

--- a/dmoj/executors/__init__.py
+++ b/dmoj/executors/__init__.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from dmoj.judgeenv import exclude_executors, only_executors
 from dmoj.utils.load import get_available_modules, load_module, load_modules
@@ -37,17 +37,17 @@ def from_filename(filename: str) -> Any:
     return by_ext(ext)
 
 
-def get_available():
+def get_available() -> List[str]:
     return get_available_modules(
         _reexecutor, os.path.dirname(__file__), only_executors, exclude_executors | _unsupported_executors
     )
 
 
-def load_executor(name):
+def load_executor(name: str) -> Any:
     return load_module(f'{__name__}.{name}', ('No module named "_cptbox"', 'No module named "termios"'))
 
 
-def load_executors():
+def load_executors() -> None:
     from dmoj.judgeenv import skip_self_test
 
     load_modules(


### PR DESCRIPTION
Add `load_executors()` so that `initialize` gets called in CI tests.