### PR TITLE
executors/NODEJS: allow `pkey_free`

### DIFF
--- a/dmoj/executors/NODEJS.py
+++ b/dmoj/executors/NODEJS.py
@@ -7,7 +7,13 @@ class Executor(ScriptExecutor):
     command = 'node'
     nproc = -1
     command_paths = ['node', 'nodejs']
-    syscalls = ['capget', 'eventfd2', 'shutdown', 'pkey_alloc']
+    syscalls = [
+        'capget',
+        'eventfd2',
+        'shutdown',
+        'pkey_alloc',
+        'pkey_free',
+    ]
     address_grace = 1048576
     test_program = """
 process.stdin.on('readable', () => {


### PR DESCRIPTION
We already allow `pkey_alloc`.