### PR TITLE
executors: globally allow THP sysfs entries

### DIFF
--- a/dmoj/executors/GO.py
+++ b/dmoj/executors/GO.py
@@ -2,7 +2,6 @@ import os
 import re
 from typing import Dict, List
 
-from dmoj.cptbox.filesystem_policies import ExactFile
 from dmoj.error import CompileError
 from dmoj.executors.base_executor import VersionFlags
 from dmoj.executors.compiled_executor import CompiledExecutor
@@ -24,11 +23,6 @@ class Executor(CompiledExecutor):
     command = 'go'
     syscalls = ['mincore', 'pselect6', 'mlock', 'setrlimit']
     compiler_syscalls = ['copy_file_range', 'setrlimit']
-    fs = [
-        # Go will start without THP information, but has some tuning for when
-        # it is available -- so let's allow it to tell.
-        ExactFile('/sys/kernel/mm/transparent_hugepage/hpage_pmd_size'),
-    ]
     test_name = 'echo'
     test_program = """\
 package main

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -67,6 +67,9 @@ else:
         ExactDir('/sys/devices/system/cpu'),
         ExactFile('/sys/devices/system/cpu/online'),
         ExactFile('/etc/selinux/config'),
+        ExactFile('/sys/kernel/mm/transparent_hugepage/enabled'),
+        ExactFile('/sys/kernel/mm/transparent_hugepage/hpage_pmd_size'),
+        ExactFile('/sys/kernel/mm/transparent_hugepage/shmem_enabled'),
     ]
 
 if sys.platform.startswith('freebsd'):


### PR DESCRIPTION
Since both Java and Go ask for them, seems reasonable to give everyone access.