### PR TITLE
executors: make compiler fs whitelists a superset of their runtimes'

### DIFF
--- a/dmoj/executors/RKT.py
+++ b/dmoj/executors/RKT.py
@@ -7,10 +7,7 @@ from dmoj.executors.compiled_executor import CompiledExecutor
 class Executor(CompiledExecutor):
     ext = 'rkt'
     fs = [RecursiveDir('/etc/racket'), ExactFile('/etc/passwd'), ExactDir('/')]
-    compiler_read_fs = [
-        RecursiveDir('/etc/racket'),
-        RecursiveDir('~/.local/share/racket'),
-    ]
+    compiler_read_fs = [RecursiveDir('~/.local/share/racket')]
 
     command = 'racket'
 

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -118,8 +118,16 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
     def get_compile_popen_kwargs(self) -> Dict[str, Any]:
         return {}
 
+    def get_compiler_read_fs(self) -> List[FilesystemAccessRule]:
+        return self.get_fs() + self.compiler_read_fs
+
+    def get_compiler_write_fs(self) -> List[FilesystemAccessRule]:
+        return self.get_write_fs() + self.compiler_write_fs
+
     def get_compiler_security(self):
-        sec = CompilerIsolateTracer(tmpdir=self._dir, read_fs=self.compiler_read_fs, write_fs=self.compiler_write_fs)
+        sec = CompilerIsolateTracer(
+            tmpdir=self._dir, read_fs=self.get_compiler_read_fs(), write_fs=self.get_compiler_write_fs()
+        )
         return self._add_syscalls(sec, self.compiler_syscalls)
 
     def create_compile_process(self, args: List[str]) -> TracedPopen:

--- a/dmoj/executors/mono_executor.py
+++ b/dmoj/executors/mono_executor.py
@@ -34,7 +34,6 @@ class MonoExecutor(CompiledExecutor):
     data_grace = 65536
     cptbox_popen_class = MonoTracedPopen
     fs = [RecursiveDir('/etc/mono')]
-    compiler_read_fs = fs
     # Mono sometimes forks during its crashdump procedure, but continues even if
     # the call to fork fails.
     syscalls = [


### PR DESCRIPTION
This makes sense because compilers are often written in the same language that they implement, so need similar whitelists.

This change enables Java 22 to compile.