### PR TITLE
tests/check_memory_limit: increase memory usage

### DIFF
--- a/testsuite/check_memory_limit/checker.py
+++ b/testsuite/check_memory_limit/checker.py
@@ -3,7 +3,7 @@ from dmoj.result import Result
 
 
 def check(process_output: bytes, judge_output: bytes, *, result: Result, **kwargs) -> bool:
-    if result.max_memory > 16384:
+    if result.max_memory > 65536:
         return False
 
     return standard.check(process_output, judge_output, result=result, **kwargs)

--- a/testsuite/check_memory_limit/tests/c_blank/test.yml
+++ b/testsuite/check_memory_limit/tests/c_blank/test.yml
@@ -1,5 +1,5 @@
 language: C
 time: 2
-memory: 65536
+memory: 262144
 source: empty.c
 expect: AC

--- a/testsuite/check_memory_limit/tests/cpp_too_much_memory/bloat.cpp
+++ b/testsuite/check_memory_limit/tests/cpp_too_much_memory/bloat.cpp
@@ -1,6 +1,6 @@
 #pragma GCC optimize "O0"
 
-const int MN = 25 * 1024 * 1024;
+const int MN = 100 * 1024 * 1024;
 char arr[MN];
 
 int main() {

--- a/testsuite/check_memory_limit/tests/cpp_too_much_memory/test.yml
+++ b/testsuite/check_memory_limit/tests/cpp_too_much_memory/test.yml
@@ -1,5 +1,5 @@
 language: CPP11
 time: 2
-memory: 65536
+memory: 262144
 source: bloat.cpp
 expect: WA


### PR DESCRIPTION
FreeBSD memory accounting is not very accurate - increasing the memory usage should make this test more robust.