### PR TITLE
executors/sbcl: increase memory limit

### DIFF
--- a/dmoj/executors/SBCL.py
+++ b/dmoj/executors/SBCL.py
@@ -3,7 +3,7 @@ from dmoj.executors.mixins import NullStdoutMixin
 
 
 # SBCL implements its own heap management, and relies on ASLR being disabled. So, on startup,
-# it reads /proc/self/exe do determine if ASLR is disabled. If not, it forks, sets
+# it reads /proc/self/exe to determine if ASLR is disabled. If not, it forks, sets
 # personality (https://man7.org/linux/man-pages/man2/personality.2.html) to disable ASLR,
 # then execve's itself...
 # As of https://github.com/DMOJ/judge-server/issues/277 we set personality ourselves to disable ASLR,
@@ -14,8 +14,8 @@ class Executor(NullStdoutMixin, CompiledExecutor):
     command = 'sbcl'
     syscalls = ['personality']
     test_program = '(write-line (read-line))'
-    address_grace = 262144
-    data_grace = 262144
+    address_grace = 524288
+    data_grace = 524288
     nproc = -1
 
     compile_script = """(compile-file "{code}")"""


### PR DESCRIPTION
the latest version of sbcl is more bloated

before:
```
0.972 Testing SBCL:   os_alloc_gc_space(1,0xb7ffb00000,173015040) failed with ENOMEM                                                                                                                       
1.032 fatal error encountered in SBCL pid 14 tid 14:                                                                                                                                                       
1.033 Can't allocate 0xa500000 bytes for space 5
1.033 
1.034 Failed self-test
1.035   Attempted:
1.036     sbcl: /usr/bin/sbcl
1.036   Errors:
1.037     Got unexpected stdout output:
1.037     
1.037 
1.038 Configuration result:
1.039 runtime: {}
```

after:
```
1.297 Testing SBCL:   Using /usr/bin/sbcl                                                                                                                                                                  
1.407   sbcl: 2.4.11                                                                                                                                                                                       
1.411 
1.411 Configuration result:
1.413 runtime:
1.413   sbcl: /usr/bin/sbcl
```