### PR TITLE
executors/go: allow new compiler syscalls

### DIFF
--- a/dmoj/executors/GO.py
+++ b/dmoj/executors/GO.py
@@ -22,7 +22,7 @@ class Executor(CompiledExecutor):
     address_grace = 786432
     command = 'go'
     syscalls = ['mincore', 'pselect6', 'mlock', 'setrlimit']
-    compiler_syscalls = ['copy_file_range', 'setrlimit']
+    compiler_syscalls = ['copy_file_range', 'setrlimit', 'pidfd_open', 'pidfd_send_signal']
     test_name = 'echo'
     test_program = """\
 package main


### PR DESCRIPTION
need these syscalls to upgrade go 1.22.5 to go 1.23.4

go took 6 seconds according to these logs
```
Sat, 21 Dec 2024 21:30:42 GMT    Testing GASARM: Unable to natively debug
Sat, 21 Dec 2024 21:30:48 GMT    Testing GO:     Using /usr/bin/go
Sat, 21 Dec 2024 21:30:48 GMT      go: 1.23.4
```