### PR TITLE
ci: update workflow versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install Black and Flake8
@@ -26,9 +26,9 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies and mypy
@@ -42,9 +42,9 @@ jobs:
   test-sdist:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install build dependencies
@@ -63,7 +63,7 @@ jobs:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download docker image
         run: docker pull dmoj/runtimes-tier3
       - name: Install python
@@ -97,7 +97,7 @@ jobs:
           EOF
 
           chmod a+x run run-su
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/docker-cache
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -119,7 +119,7 @@ jobs:
       matrix:
         python-version: [ '3.11' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download docker image
         run: docker pull dmoj/runtimes-tier3
       - name: Create docker scripts


### PR DESCRIPTION
the most important one is `actions/cache`
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down