### PR TITLE
GO: Adding eventfd2 syscall.

### DIFF
--- a/dmoj/executors/GO.py
+++ b/dmoj/executors/GO.py
@@ -21,7 +21,7 @@ class Executor(CompiledExecutor):
     data_grace = 98304  # Go uses data segment for heap arena map
     address_grace = 786432
     command = 'go'
-    syscalls = ['mincore', 'pselect6', 'mlock', 'setrlimit']
+    syscalls = ['mincore', 'pselect6', 'mlock', 'setrlimit', 'eventfd2']
     compiler_syscalls = ['copy_file_range', 'setrlimit', 'pidfd_open', 'pidfd_send_signal']
     test_name = 'echo'
     test_program = """\


### PR DESCRIPTION
Adding eventfd2 syscall, apparently used in Go from 1.23 https://github.com/golang/go/issues/65443 

I'm currently unable to submit Go code to judge due to 'RTE (eventfd2 syscall disallowed)'