### PR TITLE
executors/lean4: allow threads and add syscall

### DIFF
--- a/dmoj/executors/LEAN4.py
+++ b/dmoj/executors/LEAN4.py
@@ -10,6 +10,8 @@ def main : IO Unit := do
   let line ← cin.getLine
   IO.println line
 """
+    nproc = -1
+    syscalls = ['eventfd2']
 
     def compile(self) -> str:
         command = self.get_command()


### PR DESCRIPTION
something happened in lean 4.17.0

```
2.275 Testing executors...                                                                                                                        
2.344 Testing LEAN4:  Using /opt/lean/bin/lean                                                                                                    
6.485   lean: 4.17.0                                                                                                                              
6.510 
6.510 Configuration result:
6.510 runtime:
6.510   lean: /opt/lean/bin/lean
6.510 
6.510 Executor configuration succeeded.
```