### PR TITLE
fix: bad seccomp detection

### DIFF
--- a/dmoj/cptbox/tracer.py
+++ b/dmoj/cptbox/tracer.py
@@ -30,7 +30,7 @@ _SYSCALL_INDICIES[PTBOX_ABI_FREEBSD_X64] = 4
 _SYSCALL_INDICIES[PTBOX_ABI_ARM64] = 5
 
 FREEBSD = sys.platform.startswith('freebsd')
-BAD_SECCOMP = sys.platform == 'linux' and tuple(map(int, os.uname().release.partition('-')[0].split('.'))) < (4, 8)
+BAD_SECCOMP = is_bad_seccomp()
 
 _address_bits = {
     PTBOX_ABI_X86: 32,
@@ -424,3 +424,17 @@ class TracedPopen(Process):
 
 def can_debug(abi: int) -> bool:
     return abi in SUPPORTED_ABIS
+
+def is_bad_seccomp() -> bool:
+    try:
+        version_parts = os.uname().release.partition('-')[0].split('.')
+        clean_parts = []
+        for part in version_parts:
+            clean_part = ''.join(c for c in part if c.isdigit())
+            if clean_part:
+                clean_parts.append(int(clean_part))
+        return sys.platform == 'linux' and tuple(clean_parts) < (4, 8)
+    except (ValueError, IndexError):
+        # Default to assuming bad seccomp if we can't parse
+        return True
+    


### PR DESCRIPTION
Previous method failed for kernel versions with aditional characters like 6.6.72+

Feel free to left any comment or improvement.